### PR TITLE
Added base documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,83 @@
-# Full-Stack Project Template (Backend-Leaning)
+# ServiceDesk-Lite
 
-A reusable template repo for backend-first full-stack projects.
+ServiceDesk-Lite is a backend-focused, full-stack service desk / ticketing system designed to demonstrate
+real-world backend engineering practices using Java and Spring Boot.
 
-## Goals
-- Professional repo structure (backend, frontend, infra, docs)
-- Standardized GitHub Issues (Epics + Stories)
-- Docker-friendly local development
-- Clear documentation habits (architecture + ADRs)
+The project is intentionally scoped as a **solo-developer system** that starts small, works end-to-end,
+and grows incrementally using professional workflows (epics, stories, CI, testing, Docker).
 
-## Repo Structure
-- backend/  — API / services (e.g., Java + Spring Boot)
-- frontend/ — UI (e.g., Angular)
-- infra/    — Docker, environment examples
-- docs/     — architecture, ADRs, API notes
+---
 
-## Getting Started
-Run local infrastructure (Postgres):
-- docker compose -f infra/docker-compose.yml up -d
+## 🎯 Project Goals
 
-## Planning Standard
-We use GitHub Issues:
-- Epics = big feature areas
-- Stories = implementable work items
-- Each Epic tracks its Stories using checkboxes linking to issues:
-    - [ ] #123 Story title
+- Build a realistic backend system (not a toy CRUD app)
+- Demonstrate clean architecture and domain-driven thinking
+- Use professional tooling and workflows found in real teams
+- Be easy to run locally using Docker
+- Serve as a strong portfolio project for backend / full-stack roles
+
+---
+
+## 🧱 Core Features (Planned)
+
+- Ticket management (CRUD + lifecycle)
+- Authentication & authorization (JWT)
+- Organization-based multi-tenancy (lite)
+- Audit logging & traceability
+- API documentation (OpenAPI / Swagger)
+- CI pipeline with tests
+- Dockerized local development
+
+---
+
+## 🛠 Tech Stack
+
+### Backend
+- Java 17+
+- Spring Boot (Web, Security, Data JPA, Validation, Actuator)
+- PostgreSQL
+- Flyway migrations
+- Testcontainers (integration tests)
+
+### Frontend
+- Angular
+- TypeScript
+
+### Infrastructure
+- Docker & Docker Compose
+- GitHub Actions (CI)
+
+---
+
+## 📁 Repository Structure
+
+- backend/  — Spring Boot application
+- frontend/ — Angular application
+- infra/    — Docker Compose & environment config
+- docs/     — Architecture and API documentation
+
+---
+
+## 🚀 Local Development (high-level)
+
+Start infrastructure:
+ - docker compose -f infra/docker-compose.yml up -d
+
+Backend (later):
+ - cd backend
+ - mvn spring-boot:run
+
+Frontend (later):
+ - cd frontend
+ - npm install
+ - npm start
+
+---
+
+## 📌 Project Status
+
+This project is actively developed using GitHub Issues:
+- **Epics** = major feature areas
+- **Stories** = small, implementable units of work
+
+See the Issues tab for the roadmap and progress.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,14 +1,62 @@
-# Backend
+# Backend – ServiceDesk-Lite
 
-This folder will contain the Spring Boot application.
+This module contains the Spring Boot backend for ServiceDesk-Lite.
 
-Suggested stack:
-- Java 17+ / 21
-- Spring Boot (Web, Security, Validation, Data JPA, Actuator)
+The backend is responsible for:
+- Business logic and domain rules
+- Data persistence
+- Authentication and authorization
+- REST API exposure
+- Audit logging and traceability
+
+---
+
+## Tech Stack
+
+- Java 17+
+- Spring Boot
+- Spring Web
+- Spring Security
+- Spring Data JPA (Hibernate)
 - PostgreSQL
-- Flyway migrations
-- Testcontainers integration tests
+- Flyway
+- Testcontainers
 
-Local dev (later):
-- Start dependencies: docker compose -f ../infra/docker-compose.yml up -d
-- Run app: mvn spring-boot:run
+---
+
+## Architectural Overview
+
+The backend follows a layered architecture:
+
+- **API layer**
+    - REST controllers
+    - Request / response DTOs
+    - Validation
+
+- **Domain layer**
+    - Core business logic
+    - Domain models and rules
+
+- **Persistence layer**
+    - JPA entities
+    - Repositories
+    - Database migrations (Flyway)
+
+- **Infrastructure layer**
+    - Database configuration
+    - Security configuration
+    - Cross-cutting concerns
+
+Detailed design decisions are documented in `/docs/architecture.md`.
+
+---
+
+## Development Status
+
+The backend will be implemented incrementally, starting with:
+- Project bootstrap
+- Database setup
+- Core domain entities
+- Authentication foundation
+
+Each step is tracked as a GitHub Story under the relevant Epic.

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -1,12 +1,95 @@
-# API Contract Notes
+# API Contract
 
-Use this document to capture:
-- endpoint conventions
-- pagination format
-- error response format
-- auth headers
+This document describes the public REST API exposed by the ServiceDesk-Lite backend.
 
-## Conventions (recommended)
-- Auth header: `Authorization: Bearer <token>`
-- Pagination: `page`, `size`, `sort`
-- Error format: consistent JSON with `code`, `message`, `details`
+The API is designed to be:
+- Clear and predictable
+- Easy to consume by frontend clients
+- Explicit about authentication and authorization requirements
+
+This contract will evolve as features are implemented.
+
+---
+
+## Base Information
+
+- API style: REST
+- Data format: JSON
+- Authentication: JWT (Bearer tokens)
+- Base path (planned): /api
+
+---
+
+## Authentication (Planned)
+
+Most endpoints will require authentication using a JWT.
+
+Authentication flow:
+1. User authenticates with credentials
+2. Backend issues a JWT
+3. Client includes the token in requests using the Authorization header
+
+Authorization header format:
+Authorization: Bearer <token>
+
+---
+
+## Error Handling (Planned)
+
+Errors will be returned using a consistent JSON structure.
+
+Example error response:
+
+{
+"timestamp": "...",
+"status": 400,
+"error": "Bad Request",
+"message": "Validation failed",
+"path": "/api/example"
+}
+
+---
+
+## Endpoint Documentation Strategy
+
+Endpoints will be documented in two complementary ways:
+
+1. Human-readable documentation  
+   This file will describe endpoint intent, behavior, and constraints.
+
+2. OpenAPI / Swagger  
+   Interactive API documentation will be generated automatically and exposed
+   via Swagger UI during local development.
+
+---
+
+## Planned Core Endpoint Groups
+
+The following endpoint groups will be implemented incrementally:
+
+- Authentication
+    - User registration
+    - Login
+
+- Organizations
+    - Create organization
+    - Manage memberships
+    - Organization-level access control
+
+- Tickets
+    - Create ticket
+    - Update ticket
+    - Change ticket status
+    - List and filter tickets
+
+- Audit
+    - View audit history for entities
+
+---
+
+## Status
+
+This document is a living contract.
+
+Endpoints will be added and refined as corresponding backend stories
+are implemented and stabilized.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,18 +1,98 @@
-# Architecture
+# Architecture Overview
 
-## Overview
-This project uses a backend-first full-stack architecture:
+ServiceDesk-Lite is designed as a backend-first, modular system that emphasizes
+clear separation of concerns, maintainability, and realistic engineering practices.
 
-- Backend exposes REST APIs
-- Frontend consumes APIs
-- Infra provides local dependencies via Docker Compose
+This document provides a high-level architectural view and will evolve as the
+project grows.
 
-## Typical Components
-- API service (Spring Boot)
-- PostgreSQL database
-- Optional: Redis, message broker, observability stack
+---
 
-## Key Principles
-- Database schema managed by migrations (Flyway/Liquibase)
-- DTOs isolate API contracts from persistence entities
-- Tests include integration tests against real dependencies (Testcontainers)
+## System Overview
+
+At a high level, the system consists of:
+
+- A RESTful backend API built with Spring Boot
+- A web frontend built with Angular
+- A PostgreSQL database for persistence
+- Docker-based local infrastructure for development
+
+---
+
+## High-Level Flow
+
+1. Clients interact with the system via the frontend or API clients
+2. Requests are sent to the backend REST API
+3. Authentication and authorization are enforced at the API layer
+4. Business logic is executed in the domain layer
+5. Data is persisted in PostgreSQL
+6. Responses are returned to the client
+
+---
+
+## Backend Architecture
+
+The backend follows a layered architecture:
+
+### API Layer
+- REST controllers
+- Request and response DTOs
+- Input validation
+- Error handling
+
+### Domain Layer
+- Core business logic
+- Domain models and rules
+- No framework-specific dependencies where possible
+
+### Persistence Layer
+- JPA entities
+- Repository interfaces
+- Database migrations managed with Flyway
+
+### Infrastructure Layer
+- Database configuration
+- Security configuration
+- Cross-cutting concerns (logging, auditing)
+
+---
+
+## Security Model (High-Level)
+
+- Authentication via JWT
+- Passwords stored using strong hashing (e.g., BCrypt)
+- Authorization enforced at the API and service layers
+- Organization-based data isolation
+
+---
+
+## Data Management
+
+- PostgreSQL is the primary data store
+- Schema changes are managed through versioned Flyway migrations
+- Hibernate is used for ORM, with automatic schema generation disabled in favor of migrations
+
+---
+
+## Testing Strategy (Planned)
+
+- Unit tests for domain and service logic
+- Integration tests using Testcontainers and PostgreSQL
+- API-level tests for authentication and core workflows
+
+---
+
+## Architectural Principles
+
+- Explicit domain logic over implicit framework behavior
+- Clear ownership of responsibilities per layer
+- Predictable and repeatable local development environment
+- Evolutionary design driven by real requirements
+
+---
+
+## Evolution
+
+This architecture is expected to evolve as new features are added.
+Significant architectural decisions will be documented using ADRs
+in `docs/decisions/`.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,11 +1,45 @@
-# Frontend (Angular)
+# Frontend – ServiceDesk-Lite
 
-This folder will contain the Angular application.
+This module contains the Angular frontend for ServiceDesk-Lite.
 
-Suggested:
-- Angular + TypeScript
-- Routing + Guards
+The frontend provides the user-facing interface for interacting with the
+ServiceDesk-Lite backend APIs.
 
-Local dev (later):
-- npm install
-- npm start
+---
+
+## Responsibilities
+
+- User authentication flows
+- Ticket creation, viewing, and updates
+- Basic administrative screens
+- Client-side validation and UX
+
+---
+
+## Tech Stack
+
+- Angular
+- TypeScript
+- Angular Router
+- HTTP client for backend integration
+
+---
+
+## Architecture (High-Level)
+
+The frontend is organized around:
+- Feature-based modules
+- Reusable UI components
+- Route-based navigation
+- Service layer for API communication
+
+---
+
+## Development Status
+
+The frontend will be implemented after the backend MVP is complete.
+
+Initial work will focus on:
+- Application bootstrap
+- Authentication screens
+- Ticket management views

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,10 +1,44 @@
-# Infrastructure
+# Infrastructure – ServiceDesk-Lite
 
-Local development infrastructure lives here (Docker Compose, env examples).
+This folder contains the local development infrastructure used by ServiceDesk-Lite.
 
-Usage:
-- docker compose -f infra/docker-compose.yml up -d
-- docker compose -f infra/docker-compose.yml down
+The goal of this module is to make the project easy to run locally with minimal setup,
+using Docker to manage external dependencies.
 
-Notes:
-- Environment examples live in infra/env/
+---
+
+## Contents
+
+- `docker-compose.yml`  
+  Defines local development services.
+
+- `env/`  
+  Environment variable examples for local and test setups.
+
+---
+
+## Services (Current / Planned)
+
+- PostgreSQL database
+
+Additional services may be added as the project evolves.
+
+---
+
+## Local Development Usage
+
+Start infrastructure:
+
+ - docker compose -f infra/docker-compose.yml up -d
+
+Stop infrastructure:
+
+ - docker compose -f infra/docker-compose.yml down
+
+---
+
+## Notes
+
+- This infrastructure is intended for **local development only**
+- Production deployment is out of scope for ServiceDesk-Lite
+- Environment variables should be configured using the examples in `env/`


### PR DESCRIPTION
## Summary
It adds the base documentation to Readme's and architecture files.

## Related Issues
- Closes #3 (#2 was closed by default upon creation of repo using the template)

## How to Test
Open the readme files and they should contain no mention of template descriptions

## Checklist
- [X] Root Readme
- [X] Backend Readme
- [X] Frontend Readme
- [X] Infra Readme
- [X] api-contract.md file
- [X] architecture.md file
