### PR TITLE
Add repository standards

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Code owners
+* @EdsonR93

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,21 @@
 ## Summary
 What does this PR change?
 
-## Related Issues
-- Closes #
+## Related Issue
+Closes #
+
+## Changes
+- 
 
 ## How to Test
-Steps to verify this PR.
+Steps to verify this PR works:
+- 
+
+## Notes (optional)
+Anything reviewers should know (tradeoffs, follow-ups, screenshots).
 
 ## Checklist
-- [ ] Tests added/updated (if needed)
+- [ ] Scope is small and focused
+- [ ] Acceptance criteria met (if Story)
 - [ ] Docs updated (if needed)
 - [ ] No secrets committed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,65 @@
 # Contributing
 
-## Workflow
-- Create a branch: `feature/<short-name>` or `fix/<short-name>`
-- Open a PR early (draft is fine)
-- Link issues in PR description using `Closes #123`
+This repository follows a lightweight workflow designed for incremental delivery and clean history.
 
-## Definitions
-- **Epic**: Large work area that groups Stories
-- **Story**: Small, implementable unit with acceptance criteria
-- **Chore**: Non-feature work (refactor, config, cleanup)
-- **Bug**: Fix for incorrect behavior
+---
 
-## Quality bar
-- Keep changes small and reviewable
-- Add/adjust tests for non-trivial logic
-- Keep docs updated if behavior changes
+## Branching
+
+Create a new branch for every Story, Bug, or Chore.
+
+Recommended naming:
+- feature/story-<issue-number>-short-title
+- fix/bug-<issue-number>-short-title
+- chore/<issue-number>-short-title
+
+Examples:
+- feature/story-12-ticket-crud
+- fix/bug-33-null-pointer-login
+- chore/5-update-readme
+
+---
+
+## Commits
+
+Prefer one commit per Story when reasonable.
+
+Commit message format (suggested):
+- story(<issue-number>): short summary
+- bug(<issue-number>): short summary
+- chore(<issue-number>): short summary
+
+Examples:
+- story(12): add ticket create endpoint
+- chore(3): update repo documentation
+
+---
+
+## Pull Requests
+
+All changes merge through Pull Requests.
+
+PR requirements:
+- Link the Issue using "Closes #<issue-number>"
+- Describe what changed and why
+- Include basic test notes (even if manual)
+- Keep PRs small and focused
+
+---
+
+## Definition of Done
+
+A Story is considered done when:
+- The acceptance criteria are met
+- Code is readable and organized
+- Docs are updated if behavior changed
+- Basic tests were run (manual or automated)
+
+---
+
+## Issue Types
+
+- Epic: groups multiple Stories
+- Story: implementable unit with acceptance criteria
+- Bug: fixes incorrect behavior
+- Chore: non-feature work (cleanup, tooling, documentation)

--- a/docs/repo-standards.md
+++ b/docs/repo-standards.md
@@ -1,0 +1,66 @@
+# Repository Standards
+
+This document describes the working standards for ServiceDesk-Lite.
+
+---
+
+## Workflow Summary
+
+- Work is tracked using GitHub Issues (Epics and Stories)
+- Each Story is implemented on its own branch
+- Changes land in `dev` via Pull Requests
+- `main` receives stable milestones from `dev`
+
+Branch flow:
+feature/* -> dev -> main
+
+---
+
+## Issue Labels
+
+Core labels:
+- epic
+- story
+- bug
+- chore
+
+Optional labels:
+- backend
+- frontend
+- infra
+- docs
+- security
+- database
+- testing
+- ci
+
+---
+
+## Pull Request Guidelines
+
+PRs should:
+- Reference the Issue number
+- Explain changes clearly
+- Include test notes
+
+Link Issues using:
+Closes #<issue-number>
+
+---
+
+## Commit Guidance
+
+Prefer one commit per Story when possible.
+
+Suggested format:
+story(<issue-number>): summary
+bug(<issue-number>): summary
+chore(<issue-number>): summary
+
+---
+
+## Branch Protection
+
+We protect `dev` and `main` to prevent accidental direct commits.
+
+Checks will become required after backend/frontend build steps exist.


### PR DESCRIPTION
## Summary
- CONTRIBUTING.md updated
- PR template updated
- docs/repo-standards.md added
- CODEOWNERS added

## Related Issues
- Closes #4 

## How to Test
Open and verify the contents of the files dont have the text included with the template they were created with.

## Checklist
- [X] .gitignore, .editorconfig, .gitattributes exist (Added via template, no need to modify right now)
- [X] PR template exists
- [X] Issue templates exist (Epic/Story/Bug/Chore) (Added via template, no need to modify right now)
- [X] CONTRIBUTING.md updated
- [X] CODEOWNERS added
- [X] repo-standards.md added
