### PR TITLE
Story(1.3) Environment profiles

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -45,14 +45,33 @@
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
 
+    <!-- Persistence -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
     <!-- Standard test bundle (JUnit, Spring Test, Mockito, etc.) -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
-  </dependencies>
 
+    <!-- Embedded DB for tests only (keeps mvn test independent of Docker) -->
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
   <build>
 		<plugins>
 			<plugin>

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:postgresql://localhost:5432/servicedesk
+spring.datasource.username=servicedesk
+spring.datasource.password=servicedesk
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.open-in-view=false

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=none


### PR DESCRIPTION
## Summary
Added Dev profile to backend that successfully connects to PostgreSQL.

## Related Issues
- Closes #8 

## How to Test
From repo root run:
 - docker compose -f infra/docker-compose.yml --env-file infra/env/.env.example up -d

 On Backend/: 
 - .\mvnw.cmd test
 - .\mvnw.cmd spring-boot:run "-Dspring-boot.run.arguments=--spring.profiles.active=dev"

Expected:
- app starts without datasource errors
- /actuator/health returns UP

## Checklist
- [X] Scope is small and focused
- [X] How to Test includes: docker up + mvn test + dev run command
- [X] Tests pass locally (.\mvnw.cmd test)
- [X] No secrets committed
