### PR TITLE
Story(2.2) - Core schema migrations (users, orgs, memberships)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -65,7 +65,7 @@ Each step is tracked as a GitHub Story under the relevant Epic.
 
 ## How to test Flyway
 
-Start the backend with dev profile in the arguments:
+Start the backend with dev profile enabled:
 
  - .\mvnw.cmd spring-boot:run "-Dspring-boot.run.arguments=--spring.profiles.active=dev"
 
@@ -74,6 +74,12 @@ Verify schema table exists:
  - docker exec -it servicedesk-postgres psql -U servicedesk -d servicedesk -c "\dt"
  - docker exec -it servicedesk-postgres psql -U servicedesk -d servicedesk -c "SELECT version, description, success FROM flyway_schema_history;"
 
-It will show 1 row in the results. This confirms that Flyway ran successfully and applied the baseline migration.
+It will show 1 row in the results. This confirms that Flyway ran successfully and applied the baseline migration (V1__baseline.sql).
+
+You can verify the constraints in each table executing:
+
+ - docker exec -it servicedesk-postgres psql -U servicedesk -d servicedesk -c "\d <table_name>"
+
+Where <table_name> should match an existing table (organizations, users, memberships...).
 
 ---

--- a/backend/src/main/resources/db/migration/V2__core_users_orgs_memberships.sql
+++ b/backend/src/main/resources/db/migration/V2__core_users_orgs_memberships.sql
@@ -1,0 +1,37 @@
+-- Core identity schema: organizations, users, memberships
+-- Postgres only
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- Organizations (tenants)
+CREATE TABLE IF NOT EXISTS organizations (
+                                             id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name        VARCHAR(200) NOT NULL,
+    slug        VARCHAR(80)  NOT NULL UNIQUE,
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ  NOT NULL DEFAULT now()
+    );
+
+-- Users (identities)
+CREATE TABLE IF NOT EXISTS users (
+                                     id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email         VARCHAR(320) NOT NULL UNIQUE,
+    full_name     VARCHAR(200),
+    password_hash VARCHAR(255),
+    status        VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+
+-- Memberships (user <-> org with role)
+CREATE TABLE IF NOT EXISTS memberships (
+                                           id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id      UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    user_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    role        VARCHAR(20) NOT NULL DEFAULT 'REQUESTER',
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT uq_membership_org_user UNIQUE (org_id, user_id)
+    );
+
+CREATE INDEX IF NOT EXISTS idx_memberships_org_id ON memberships(org_id);
+CREATE INDEX IF NOT EXISTS idx_memberships_user_id ON memberships(user_id);


### PR DESCRIPTION
## Summary
Included core schema for users, organizations and memberships while also documenting the readme to reflect the changes and how to verify them.

## Related Issue
Closes #11 

## How to Test
Start the backend with dev profile enabled:
 - .\mvnw.cmd spring-boot:run "-Dspring-boot.run.arguments=--spring.profiles.active=dev"

Verify schema table exists:
 - docker exec -it servicedesk-postgres psql -U servicedesk -d servicedesk -c "\dt"

You can verify the constraints in each table executing:
 - docker exec -it servicedesk-postgres psql -U servicedesk -d servicedesk -c "\d <table_name>"

Where <table_name> should match an existing table (organizations, users, memberships...).

## Checklist
- [X] Migration added for orgs/users/memberships.
- [X] Flyway applies migration cleanly on startup (dev).
- [X] Verified tables exist via psql.
- [X] No destructive changes.
- [X] Docs updated.