### PR TITLE
Story (3.1) - User registration

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -52,6 +52,16 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
       <scope>runtime</scope>

--- a/backend/src/main/java/com/servicedesk/lite/auth/AuthController.java
+++ b/backend/src/main/java/com/servicedesk/lite/auth/AuthController.java
@@ -1,0 +1,28 @@
+package com.servicedesk.lite.auth;
+
+import com.servicedesk.lite.auth.dto.RegisterRequest;
+import com.servicedesk.lite.auth.dto.RegisterResponse;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+
+    @PostMapping("/register")
+    public RegisterResponse register(@Valid @RequestBody RegisterRequest request) {
+        UUID id = authService.register(request);
+        return new RegisterResponse(id);
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/auth/AuthService.java
+++ b/backend/src/main/java/com/servicedesk/lite/auth/AuthService.java
@@ -1,0 +1,47 @@
+package com.servicedesk.lite.auth;
+
+import com.servicedesk.lite.auth.dto.RegisterRequest;
+import com.servicedesk.lite.auth.exception.EmailAlreadyExistsException;
+import com.servicedesk.lite.user.Status;
+import com.servicedesk.lite.user.User;
+import com.servicedesk.lite.user.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    public AuthService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+    @Transactional
+    public UUID register(RegisterRequest registerRequest) {
+
+        String emailNormalized = registerRequest.getEmail().trim().toLowerCase();
+        if (userRepository.existsByEmailIgnoreCase(emailNormalized)) {
+            throw new EmailAlreadyExistsException(emailNormalized);
+        }
+
+        String hashedPassword = passwordEncoder.encode(registerRequest.getPassword());
+
+        String fullName;
+        if(registerRequest.getFullName() != null && !registerRequest.getFullName().trim().isEmpty()) {
+            fullName = registerRequest.getFullName().trim();
+        }else{
+            fullName = null;
+        }
+
+        User newUser;
+
+        newUser = userRepository.save(new User(emailNormalized, hashedPassword, fullName, Status.ACTIVE));
+        return newUser.getId();
+
+    }
+
+}

--- a/backend/src/main/java/com/servicedesk/lite/auth/dto/RegisterRequest.java
+++ b/backend/src/main/java/com/servicedesk/lite/auth/dto/RegisterRequest.java
@@ -1,0 +1,42 @@
+package com.servicedesk.lite.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class RegisterRequest {
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    @Size(min = 8, max = 255)
+    private String password;
+
+    private String fullName;
+
+    public String getFullName() {
+        return fullName;
+    }
+
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/auth/dto/RegisterResponse.java
+++ b/backend/src/main/java/com/servicedesk/lite/auth/dto/RegisterResponse.java
@@ -1,0 +1,15 @@
+package com.servicedesk.lite.auth.dto;
+
+import java.util.UUID;
+
+public class RegisterResponse {
+    private final UUID userId;
+
+    public RegisterResponse(UUID userId) {
+        this.userId = userId;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/auth/exception/EmailAlreadyExistsException.java
+++ b/backend/src/main/java/com/servicedesk/lite/auth/exception/EmailAlreadyExistsException.java
@@ -1,0 +1,14 @@
+package com.servicedesk.lite.auth.exception;
+
+public class EmailAlreadyExistsException extends RuntimeException {
+    private final String email;
+
+    public EmailAlreadyExistsException(String email) {
+        super("Email already exists: " + email);
+        this.email = email;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/auth/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/servicedesk/lite/auth/exception/GlobalExceptionHandler.java
@@ -1,0 +1,26 @@
+package com.servicedesk.lite.auth.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+import static org.springframework.http.HttpStatus.CONFLICT;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(EmailAlreadyExistsException.class)
+    public ResponseEntity<?> handleEmailAlreadyExists(EmailAlreadyExistsException ex, HttpServletRequest request) {
+        return ResponseEntity.status(CONFLICT).body(Map.of(
+            "timestamp", OffsetDateTime.now().toString(),
+            "status", 409,
+            "error","Conflict",
+            "message", ex.getMessage(),
+            "path",request.getRequestURI()
+        ));
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/config/SecurityConfig.java
+++ b/backend/src/main/java/com/servicedesk/lite/config/SecurityConfig.java
@@ -1,0 +1,32 @@
+package com.servicedesk.lite.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.http.HttpMethod;
+
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder(); // default strength is fine now
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(HttpMethod.POST, "/api/auth/register").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/auth/login").permitAll()
+                .requestMatchers(HttpMethod.GET, "/actuator/health").permitAll()
+                .anyRequest().permitAll() // later -> authenticated()
+            );
+        return http.build();
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/user/Status.java
+++ b/backend/src/main/java/com/servicedesk/lite/user/Status.java
@@ -1,0 +1,14 @@
+package com.servicedesk.lite.user;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public enum Status {
+    ACTIVE, DISABLED;
+
+    public static Optional<Status> from(String value) {
+        return Arrays.stream(values())
+            .filter(s -> s.name().equalsIgnoreCase(value))
+            .findFirst();
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/user/User.java
+++ b/backend/src/main/java/com/servicedesk/lite/user/User.java
@@ -1,0 +1,87 @@
+package com.servicedesk.lite.user;
+
+import jakarta.persistence.*;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name="users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name="id")
+    private UUID id;
+
+    @Column(name="email",nullable = false, unique = true, length = 320)
+    private String email;
+
+    @Column(name="password_hash", length = 255)
+    private String passwordHash;
+
+    @Column(name="full_name", length = 200)
+    private String fullName;
+
+    @Column(name="status",nullable = false, length = 20)
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    @Column(name="created_at", insertable = false,updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name="updated_at", insertable = false,updatable = false)
+    private OffsetDateTime updatedAt;
+
+    protected User() {}
+    public User(String email, String passwordHash, String fullName, Status status) {
+
+        this.email = email;
+        this.passwordHash = passwordHash;
+        this.fullName = fullName;
+        this.status = status;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public void setPasswordHash(String passwordHash) {
+        this.passwordHash = passwordHash;
+    }
+
+    public String getFullName() {
+        return fullName;
+    }
+
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public OffsetDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/user/UserRepository.java
+++ b/backend/src/main/java/com/servicedesk/lite/user/UserRepository.java
@@ -1,0 +1,12 @@
+package com.servicedesk.lite.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+
+    boolean existsByEmailIgnoreCase(String email);
+    Optional<User> findByEmailIgnoreCase(String email);
+}

--- a/backend/src/main/resources/db/migration/V2__core_users_orgs_memberships.sql
+++ b/backend/src/main/resources/db/migration/V2__core_users_orgs_memberships.sql
@@ -44,5 +44,3 @@ ALTER TABLE users
 CREATE INDEX IF NOT EXISTS idx_memberships_org_id ON memberships(org_id);
 CREATE INDEX IF NOT EXISTS idx_memberships_user_id ON memberships(user_id);
 CREATE UNIQUE INDEX uq_users_email_lower ON users (lower(email));
-
-Added check constraints to memberships and users, Added update triggers for updated_at in the tables that have it, updated the readme documentation accordingly


### PR DESCRIPTION
## Summary
Adds the first end-to-end auth flow: a public registration endpoint that validates input, hashes passwords with BCrypt, persists a new User, and returns the created userId. Also introduces a dedicated exception + global handler to return a clean 409 Conflict when the email already exists.

## Related Issue
Closes #13

## Changes
- Added Spring Security baseline config (SecurityConfig) and exposed /api/auth/register, /api/auth/login, and /actuator/health as public endpoints (temporary permitAll for the rest during Epic 3 bootstrapping).
- Introduced User domain persistence:
   - User JPA entity mapped to users table (UUID, email, fullName, passwordHash, status, timestamps).
   - Status enum stored as STRING.
   - UserRepository with case-insensitive lookup helpers.
- Implemented registration logic in AuthService:
   - Normalize email (trim + lowercase)
   - Reject duplicates with a custom exception
   - Hash password with PasswordEncoder (BCrypt)
   - Persist new user with Status.ACTIVE
   - Return created user UUID
- Added API layer:
   - RegisterRequest DTO with validation annotations (email + password required; fullName optional)
   - RegisterResponse DTO returning userId
   - AuthController exposing POST /api/auth/register
- Added error handling:
   - EmailAlreadyExistsException
   - GlobalExceptionHandler (@RestControllerAdvice) mapping it to 409 Conflict
- Fixed DB insert behavior for timestamp columns to rely on DB defaults/triggers (avoid null inserts for created_at / updated_at).

## How to Test
Start backend (dev profile):
   - .\mvnw.cmd spring-boot:run "-Dspring-boot.run.arguments=--spring.profiles.active=dev"

Register a new user (expect 200 + userId):

PowerShell:
curl -Method POST http://localhost:8080/api/auth/register -ContentType "application/json" -Body '{"email":"test@example.com","password":"Password123!","fullName":"Test User"}'

Register same email again (expect 409 Conflict):

curl -Method POST http://localhost:8080/api/auth/register -ContentType "application/json" -Body '{"email":"test@example.com","password":"Password123!","fullName":"Test User"}'

(Optional) Verify row exists in DB:

docker exec -it servicedesk-postgres psql -U servicedesk -d servicedesk -c "SELECT id, email, full_name, status FROM users WHERE lower(email) = 'test@example.com';"

## Notes (optional)
- SecurityConfig currently permits all requests while Epic 3 is being built; later stories will switch to authenticated endpoints and JWT enforcement.
- created_at / updated_at are expected to be managed by DB defaults/triggers; entity mappings are set to avoid sending nulls for these columns.
- Follow-up work in Story 3.2 will add login + JWT issuance.

## Checklist
- [X] SecurityConfig exists and app starts with dev profile
- [X]  User JPA entity mapped to users table (UUID id, email, fullName, passwordHash, status, createdAt, updatedAt)
- [X]  Status enum exists and is stored as STRING
- [X]  UserRepository extends JpaRepository<User, UUID>
- [X]  Repository methods exist:
   - [X]  existsByEmailIgnoreCase(String email)
   - [X]  findByEmailIgnoreCase(String email)
- [X]  DTOs created:
   - [X]  RegisterRequest with validation annotations (email + password required, fullName optional)
   - [X]  RegisterResponse returns userId
- [X]  AuthService.register(...) implemented:
   - [X]  normalizes email (trim + lowercase)
   - [X]  checks duplicates and throws EmailAlreadyExistsException
   - [X]  hashes password with PasswordEncoder (BCrypt)
   - [X]  saves User with Status.ACTIVE
   - [X]  returns created user UUID
- [X]  AuthController exposes POST /api/auth/register and returns RegisterResponse
- [X]  EmailAlreadyExistsException created under com.servicedesk.lite.auth.exception
- [X]  GlobalExceptionHandler (@RestControllerAdvice) handles EmailAlreadyExistsException and returns 409 Conflict
- [X]  created_at / updated_at persistence aligned with DB defaults/triggers (no null insert issue)
- [X]  Manual test passes:
   - [X]  First register call returns 200 with userId
   - [X]  Second call with same email returns 409
