### PR TITLE
Epic 4 / Story 4.1: Create organization + creator admin membership

### DIFF
--- a/backend/src/main/java/com/servicedesk/lite/membership/Membership.java
+++ b/backend/src/main/java/com/servicedesk/lite/membership/Membership.java
@@ -28,8 +28,7 @@ public class Membership {
 
     public Membership() {}
 
-    public Membership(UUID id, UUID orgId, UUID userId, MembershipRole role) {
-        this.id = id;
+    public Membership(UUID orgId, UUID userId, MembershipRole role) {
         this.orgId = orgId;
         this.userId = userId;
         this.role = role;

--- a/backend/src/main/java/com/servicedesk/lite/membership/Membership.java
+++ b/backend/src/main/java/com/servicedesk/lite/membership/Membership.java
@@ -1,0 +1,73 @@
+package com.servicedesk.lite.membership;
+
+import jakarta.persistence.*;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name="memberships")
+public class Membership {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name="id")
+    private UUID id;
+
+    @Column(name="org_id",nullable = false)
+    private UUID orgId;
+
+    @Column(name="user_id",nullable = false)
+    private UUID userId;
+
+    @Column(name="role",nullable = false,length=20)
+    @Enumerated(EnumType.STRING)
+    private MembershipRole role;
+
+    @Column(name="created_at", insertable = false,updatable = false)
+    private OffsetDateTime createdAt;
+
+    public Membership() {}
+
+    public Membership(UUID id, UUID orgId, UUID userId, MembershipRole role) {
+        this.id = id;
+        this.orgId = orgId;
+        this.userId = userId;
+        this.role = role;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getOrgId() {
+        return orgId;
+    }
+
+    public void setOrgId(UUID orgId) {
+        this.orgId = orgId;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public void setUserId(UUID userId) {
+        this.userId = userId;
+    }
+
+    public MembershipRole getRole() {
+        return role;
+    }
+
+    public void setRole(MembershipRole role) {
+        this.role = role;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/membership/MembershipRepository.java
+++ b/backend/src/main/java/com/servicedesk/lite/membership/MembershipRepository.java
@@ -1,0 +1,12 @@
+package com.servicedesk.lite.membership;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface MembershipRepository extends JpaRepository<Membership, UUID> {
+
+    boolean existsByOrgIdAndUserId(UUID orgId, UUID userId);
+    Optional<Membership> findByUserIdAndOrgId(UUID userId, UUID orgId);
+}

--- a/backend/src/main/java/com/servicedesk/lite/membership/MembershipRole.java
+++ b/backend/src/main/java/com/servicedesk/lite/membership/MembershipRole.java
@@ -1,0 +1,14 @@
+package com.servicedesk.lite.membership;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public enum MembershipRole {
+    ADMIN, AGENT, REQUESTER;
+
+    public static Optional<MembershipRole> from(String value) {
+        return Arrays.stream(values())
+            .filter(s -> s.name().equalsIgnoreCase(value))
+            .findFirst();
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/org/Organization.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/Organization.java
@@ -1,0 +1,66 @@
+package com.servicedesk.lite.org;
+
+import jakarta.persistence.*;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name="organizations")
+public class Organization {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name="id")
+    private UUID id;
+
+    @Column(name="name",nullable = false,length=200)
+    private String name;
+
+    @Column(name="slug",nullable = false,length=80,unique=true)
+    private String slug;
+
+    @Column(name="created_at", insertable = false,updatable = false)
+    private OffsetDateTime  createdAt;
+
+    @Column(name="updated_at", insertable = false,updatable = false)
+    private OffsetDateTime  updatedAt;
+
+    public Organization() {}
+
+    public Organization(String name, String slug) {
+        this.name = name;
+        this.slug = slug;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSlug() {
+        return slug;
+    }
+
+    public void setSlug(String slug) {
+        this.slug = slug;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public OffsetDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/org/OrganizationController.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/OrganizationController.java
@@ -1,0 +1,29 @@
+package com.servicedesk.lite.org;
+
+import com.servicedesk.lite.org.dto.CreateOrganizationRequest;
+import com.servicedesk.lite.org.dto.CreateOrganizationResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/organizations")
+public class OrganizationController {
+    private final OrganizationService organizationService;
+
+    public OrganizationController(OrganizationService organizationService) {
+        this.organizationService = organizationService;
+    }
+
+    @PostMapping("/")
+    @ResponseStatus(HttpStatus.CREATED)
+    public CreateOrganizationResponse createOrganization(@Valid @RequestBody CreateOrganizationRequest req, @AuthenticationPrincipal Jwt jwt) {
+        UUID creatorId = UUID.fromString(jwt.getSubject());
+        UUID orgId = organizationService.createOrganization(req, creatorId);
+        return new CreateOrganizationResponse(orgId);
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/org/OrganizationRepository.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/OrganizationRepository.java
@@ -1,0 +1,10 @@
+package com.servicedesk.lite.org;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.UUID;
+
+public interface OrganizationRepository extends JpaRepository<Organization, UUID> {
+
+    boolean existsByNameIgnoreCase(String name);
+    boolean existsBySlug(String slug);
+}

--- a/backend/src/main/java/com/servicedesk/lite/org/OrganizationService.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/OrganizationService.java
@@ -1,0 +1,4 @@
+package com.servicedesk.lite.org;
+
+public class OrganizationService {
+}

--- a/backend/src/main/java/com/servicedesk/lite/org/OrganizationService.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/OrganizationService.java
@@ -23,7 +23,8 @@ public class OrganizationService {
     @Transactional
     public UUID createOrganization(CreateOrganizationRequest req, UUID creatorUserId){
         Organization savedOrg = organizationRepository.save(new Organization(req.getName(), req.getSlug()));
-        membershipRepository.save(new Membership(savedOrg.getId(), creatorUserId, MembershipRole.ADMIN));
-        return savedOrg.getId();
+        UUID orgId = savedOrg.getId();
+        membershipRepository.save(new Membership(orgId, creatorUserId, MembershipRole.ADMIN));
+        return orgId;
     }
 }

--- a/backend/src/main/java/com/servicedesk/lite/org/OrganizationService.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/OrganizationService.java
@@ -1,4 +1,29 @@
 package com.servicedesk.lite.org;
 
+import com.servicedesk.lite.membership.Membership;
+import com.servicedesk.lite.membership.MembershipRepository;
+import com.servicedesk.lite.membership.MembershipRole;
+import com.servicedesk.lite.org.dto.CreateOrganizationRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
 public class OrganizationService {
+    private final OrganizationRepository organizationRepository;
+    private final MembershipRepository membershipRepository;
+
+
+    public OrganizationService(OrganizationRepository organizationRepository, MembershipRepository membershipRepository) {
+        this.organizationRepository = organizationRepository;
+        this.membershipRepository = membershipRepository;
+    }
+
+    @Transactional
+    public UUID createOrganization(CreateOrganizationRequest req, UUID creatorUserId){
+        Organization savedOrg = organizationRepository.save(new Organization(req.getName(), req.getSlug()));
+        membershipRepository.save(new Membership(savedOrg.getId(), creatorUserId, MembershipRole.ADMIN));
+        return savedOrg.getId();
+    }
 }

--- a/backend/src/main/java/com/servicedesk/lite/org/dto/CreateOrganizationRequest.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/dto/CreateOrganizationRequest.java
@@ -1,0 +1,30 @@
+package com.servicedesk.lite.org.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public class CreateOrganizationRequest {
+
+    @NotNull @Size(min=1,max=200)
+    private String name;
+
+    @NotNull @Size(min=1,max=80) @Pattern(regexp = "^[a-z0-9]+(?:-[a-z0-9]+)*$")
+    private String slug;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSlug() {
+        return slug;
+    }
+
+    public void setSlug(String slug) {
+        this.slug = slug;
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/org/dto/CreateOrganizationRequest.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/dto/CreateOrganizationRequest.java
@@ -1,15 +1,15 @@
 package com.servicedesk.lite.org.dto;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public class CreateOrganizationRequest {
 
-    @NotNull @Size(min=1,max=200)
+    @NotBlank @Size(max=200)
     private String name;
 
-    @NotNull @Size(min=1,max=80) @Pattern(regexp = "^[a-z0-9]+(?:-[a-z0-9]+)*$")
+    @NotBlank @Size(max=80) @Pattern(regexp = "^[a-z0-9]+(?:-[a-z0-9]+)*$")
     private String slug;
 
     public String getName() {

--- a/backend/src/main/java/com/servicedesk/lite/org/dto/CreateOrganizationRequest.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/dto/CreateOrganizationRequest.java
@@ -27,4 +27,5 @@ public class CreateOrganizationRequest {
     public void setSlug(String slug) {
         this.slug = slug;
     }
+
 }

--- a/backend/src/main/java/com/servicedesk/lite/org/dto/CreateOrganizationResponse.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/dto/CreateOrganizationResponse.java
@@ -1,0 +1,15 @@
+package com.servicedesk.lite.org.dto;
+
+import java.util.UUID;
+
+public class CreateOrganizationResponse {
+    private final UUID id;
+
+    public CreateOrganizationResponse(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/org/exception/OrgExceptionHandler.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/exception/OrgExceptionHandler.java
@@ -1,0 +1,40 @@
+package com.servicedesk.lite.org.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+import static org.springframework.http.HttpStatus.CONFLICT;
+
+@RestControllerAdvice(basePackages = "com.servicedesk.lite.org")
+public class OrgExceptionHandler {
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<?> createOrganization(DataIntegrityViolationException ex, HttpServletRequest request) {
+        String message = ex.getMostSpecificCause().getMessage();
+
+        if(message != null && message.contains("organizations_slug_key")){
+            return ResponseEntity.status(CONFLICT).body(Map.of(
+                "timestamp", OffsetDateTime.now().toString(),
+                "status", 409,
+                "error","Conflict",
+                "message", "Organization slug already exists",
+                "path",request.getRequestURI()
+            ));
+        }
+
+        return ResponseEntity.status(CONFLICT).body(Map.of(
+            "timestamp", OffsetDateTime.now().toString(),
+            "status", 409,
+            "error","Conflict",
+            "message", "Conflict",
+            "path",request.getRequestURI()
+        ));
+
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/user/User.java
+++ b/backend/src/main/java/com/servicedesk/lite/user/User.java
@@ -1,7 +1,6 @@
 package com.servicedesk.lite.user;
 
 import jakarta.persistence.*;
-
 import java.time.OffsetDateTime;
 import java.util.UUID;
 

--- a/backend/src/main/java/com/servicedesk/lite/user/UserRepository.java
+++ b/backend/src/main/java/com/servicedesk/lite/user/UserRepository.java
@@ -1,7 +1,6 @@
 package com.servicedesk.lite.user;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
 import java.util.UUID;
 


### PR DESCRIPTION
## Summary
Adds the Story 4.1 create-organization flow. Authenticated users can create an organization, and the creator is automatically added as an ADMIN member. Duplicate org slugs return a 409 instead of a 500.

## Related Issue
Closes #17

## Changes
- Added POST /api/organizations endpoint (JWT-authenticated)
- Implemented transactional org creation + creator ADMIN membership creation
- Added request validation for org name/slug
- Added org-scoped exception handler to map duplicate slug (organizations_slug_key) to HTTP 409 Conflict

## How to Test
- Start Postgres (Docker) and run the Spring Boot app
- In Postman:
    - POST /api/auth/register (or use an existing user)
    - POST /api/auth/login and store token
    - POST /api/organizations with body:
        - { "name": "Acme Corp", "slug": "acme" } → expect 201/200 with { "id": "..." }
    - Repeat POST /api/organizations with the same slug acme → expect 409 Conflict with message Organization slug already exists
- Verify DB:
    - organizations has the new org row
    - memberships has a row with role = ADMIN for (org_id, user_id) of the creator

## Notes (optional)
- Duplicate slug handling is based on matching Postgres constraint name organizations_slug_key.

## Checklist
- [X] Scope is small and focused
- [X] Acceptance criteria met (if Story)
- [X] No secrets committed
