### PR TITLE
Epic 4 / Story 4.2: Admin membership management

### DIFF
--- a/backend/src/main/java/com/servicedesk/lite/org/MembershipController.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/MembershipController.java
@@ -1,0 +1,29 @@
+package com.servicedesk.lite.org;
+
+import com.servicedesk.lite.org.dto.AddMemberRequest;
+import com.servicedesk.lite.org.dto.AddMemberResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/organizations/{orgId}/memberships")
+public class MembershipController {
+    private final MembershipService membershipService;
+
+    public MembershipController(MembershipService membershipService) {
+        this.membershipService = membershipService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public AddMemberResponse createMembership(@PathVariable UUID orgId, @Valid @RequestBody AddMemberRequest req, @AuthenticationPrincipal Jwt jwt) {
+        UUID callerId = UUID.fromString(jwt.getSubject());
+        UUID membershipId = membershipService.addMember(orgId, callerId, req);
+        return new AddMemberResponse(membershipId);
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/org/MembershipService.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/MembershipService.java
@@ -1,0 +1,43 @@
+package com.servicedesk.lite.org;
+
+import com.servicedesk.lite.membership.Membership;
+import com.servicedesk.lite.membership.MembershipRepository;
+import com.servicedesk.lite.membership.MembershipRole;
+import com.servicedesk.lite.org.dto.AddMemberRequest;
+import com.servicedesk.lite.org.exception.OrgForbiddenException;
+import com.servicedesk.lite.org.exception.UserNotFoundException;
+import com.servicedesk.lite.user.User;
+import com.servicedesk.lite.user.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class MembershipService {
+    private final MembershipRepository membershipRepository;
+    private final UserRepository userRepository;
+
+
+    public MembershipService(MembershipRepository membershipRepository, UserRepository userRepository) {
+        this.membershipRepository = membershipRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Transactional
+    public UUID addMember(UUID orgId, UUID callerUserId, AddMemberRequest req) {
+        Optional<Membership> membershipOpt = membershipRepository.findByUserIdAndOrgId(callerUserId, orgId);
+        Membership callerMembership = membershipOpt.orElseThrow((() -> new OrgForbiddenException("Not an org admin")));
+        if (callerMembership.getRole() != MembershipRole.ADMIN) {
+            throw new OrgForbiddenException("Not an org admin");
+        }
+
+        String email = req.getEmail().trim().toLowerCase();
+        Optional<User> targetUserOpt = userRepository.findByEmailIgnoreCase(email);
+        User targetUser = targetUserOpt.orElseThrow((() -> new UserNotFoundException("User with email: " + email + " not found")));
+
+        Membership newMembership = membershipRepository.save(new Membership(orgId, targetUser.getId(), req.getRole()));
+        return newMembership.getId();
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/org/dto/AddMemberRequest.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/dto/AddMemberRequest.java
@@ -1,4 +1,41 @@
 package com.servicedesk.lite.org.dto;
 
+import com.servicedesk.lite.membership.MembershipRole;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 public class AddMemberRequest {
+    @NotBlank
+    @Email
+    @Size(max = 255)
+    private String email;
+
+    @NotNull
+    private MembershipRole role;
+
+    public AddMemberRequest() {
+    }
+
+    public AddMemberRequest(String email, MembershipRole role) {
+        this.email = email;
+        this.role = role;
+    }
+
+    public void setRole(MembershipRole role) {
+        this.role = role;
+    }
+
+    public MembershipRole getRole() {
+        return role;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getEmail() {
+        return email;
+    }
 }

--- a/backend/src/main/java/com/servicedesk/lite/org/dto/AddMemberRequest.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/dto/AddMemberRequest.java
@@ -1,0 +1,4 @@
+package com.servicedesk.lite.org.dto;
+
+public class AddMemberRequest {
+}

--- a/backend/src/main/java/com/servicedesk/lite/org/dto/AddMemberResponse.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/dto/AddMemberResponse.java
@@ -1,0 +1,4 @@
+package com.servicedesk.lite.org.dto;
+
+public class AddMemberResponse {
+}

--- a/backend/src/main/java/com/servicedesk/lite/org/dto/AddMemberResponse.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/dto/AddMemberResponse.java
@@ -1,4 +1,16 @@
 package com.servicedesk.lite.org.dto;
 
+import java.util.UUID;
+
 public class AddMemberResponse {
+
+    private final UUID id;
+
+    public AddMemberResponse(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getId() {
+        return id;
+    }
 }

--- a/backend/src/main/java/com/servicedesk/lite/org/exception/OrgExceptionHandler.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/exception/OrgExceptionHandler.java
@@ -9,32 +9,65 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.time.OffsetDateTime;
 import java.util.Map;
 
-import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.*;
 
 @RestControllerAdvice(basePackages = "com.servicedesk.lite.org")
 public class OrgExceptionHandler {
 
     @ExceptionHandler(DataIntegrityViolationException.class)
-    public ResponseEntity<?> createOrganization(DataIntegrityViolationException ex, HttpServletRequest request) {
+    public ResponseEntity<?> handleDataIntegrityViolationException(DataIntegrityViolationException ex, HttpServletRequest request) {
         String message = ex.getMostSpecificCause().getMessage();
 
-        if(message != null && message.contains("organizations_slug_key")){
-            return ResponseEntity.status(CONFLICT).body(Map.of(
-                "timestamp", OffsetDateTime.now().toString(),
-                "status", 409,
-                "error","Conflict",
-                "message", "Organization slug already exists",
-                "path",request.getRequestURI()
-            ));
+        if (message != null) {
+            if (message.contains("organizations_slug_key")) {
+                return ResponseEntity.status(CONFLICT).body(Map.of(
+                    "timestamp", OffsetDateTime.now().toString(),
+                    "status", 409,
+                    "error", "Conflict",
+                    "message", "Organization slug already exists",
+                    "path", request.getRequestURI()
+                ));
+            } else if (message.contains("uq_membership_org_user")) {
+                return ResponseEntity.status(CONFLICT).body(Map.of(
+                    "timestamp", OffsetDateTime.now().toString(),
+                    "status", 409,
+                    "error", "Conflict",
+                    "message", "User is already a member of this organization",
+                    "path", request.getRequestURI()
+                ));
+            }
         }
+
 
         return ResponseEntity.status(CONFLICT).body(Map.of(
             "timestamp", OffsetDateTime.now().toString(),
             "status", 409,
-            "error","Conflict",
+            "error", "Conflict",
             "message", "Conflict",
-            "path",request.getRequestURI()
+            "path", request.getRequestURI()
         ));
 
+    }
+
+    @ExceptionHandler(OrgForbiddenException.class)
+    public ResponseEntity<?> handleOrgForbiddenException(OrgForbiddenException ex, HttpServletRequest request) {
+        return ResponseEntity.status(FORBIDDEN).body(Map.of(
+            "timestamp", OffsetDateTime.now().toString(),
+            "status", 403,
+            "error", "Forbidden",
+            "message", ex.getMessage(),
+            "path", request.getRequestURI()
+        ));
+    }
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<?> handleUserNotFoundException(UserNotFoundException ex, HttpServletRequest request) {
+        return ResponseEntity.status(NOT_FOUND).body(Map.of(
+            "timestamp", OffsetDateTime.now().toString(),
+            "status", 404,
+            "error", "Not found",
+            "message", ex.getMessage(),
+            "path", request.getRequestURI()
+        ));
     }
 }

--- a/backend/src/main/java/com/servicedesk/lite/org/exception/OrgForbiddenException.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/exception/OrgForbiddenException.java
@@ -1,0 +1,7 @@
+package com.servicedesk.lite.org.exception;
+
+public class OrgForbiddenException extends RuntimeException {
+    public OrgForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/org/exception/UserNotFoundException.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.servicedesk.lite.org.exception;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## Summary
Adds admin-only membership management for organizations. Org admins can add existing users to an organization with a specified role.

## Related Issue
Closes #18

## Changes
- Added MembershipService with admin authorization check
- Added POST /api/organizations/{orgId}/memberships
- Added OrgForbiddenException and UserNotFoundException
- Extended OrgExceptionHandler to map:
    - 403 (not admin)
    - 404 (user not found)
    - 409 (duplicate membership)

## How to Test
- Create org as User A
- Add User B as AGENT → success
- Add User B again → 409
- Login as User B and attempt to add → 403
- Add unknown email → 404

## Notes (optional)
Anything reviewers should know (tradeoffs, follow-ups, screenshots).

## Checklist
- [X] Scope is small and focused
- [X] Acceptance criteria met
- [X] No secrets committed
