### PR TITLE
Feature - Story4.4 Org - level data isolation enforcement

### DIFF
--- a/backend/src/main/java/com/servicedesk/lite/config/SecurityConfig.java
+++ b/backend/src/main/java/com/servicedesk/lite/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.servicedesk.lite.config;
 
+import com.servicedesk.lite.membership.MembershipRepository;
+import com.servicedesk.lite.org.context.OrgContextFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -9,6 +11,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 
 
@@ -23,7 +26,7 @@ public class SecurityConfig {
 
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http, JwtAuthenticationConverter jwtAuthConverter) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http, JwtAuthenticationConverter jwtAuthConverter, OrgContextFilter orgContextFilter) throws Exception {
         http
             .csrf(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests(auth -> auth
@@ -34,7 +37,13 @@ public class SecurityConfig {
                 .anyRequest().permitAll() // later -> authenticated()
             ).oauth2ResourceServer((oauth2ResourceServer) ->
                 oauth2ResourceServer
-                    .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthConverter)));
+                    .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthConverter)))
+            .addFilterAfter(orgContextFilter, BearerTokenAuthenticationFilter.class);
         return http.build();
+    }
+
+    @Bean
+    public OrgContextFilter getOrgContextFilter(MembershipRepository membershipRepository) {
+        return new OrgContextFilter(membershipRepository);
     }
 }

--- a/backend/src/main/java/com/servicedesk/lite/org/context/OrgContext.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/context/OrgContext.java
@@ -1,0 +1,22 @@
+package com.servicedesk.lite.org.context;
+
+import java.util.UUID;
+
+public final class OrgContext {
+    private static final ThreadLocal<UUID> ORG_ID = new ThreadLocal<>();
+
+    private OrgContext() {
+    }
+
+    public static UUID getOrgId() {
+        return ORG_ID.get();
+    }
+
+    public static void setOrgId(UUID orgId) {
+        ORG_ID.set(orgId);
+    }
+
+    public static void clear() {
+        ORG_ID.remove();
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/org/context/OrgContextFilter.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/context/OrgContextFilter.java
@@ -1,0 +1,68 @@
+package com.servicedesk.lite.org.context;
+
+import com.servicedesk.lite.membership.MembershipRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+public class OrgContextFilter extends OncePerRequestFilter {
+    private final MembershipRepository membershipRepository;
+
+    public OrgContextFilter(MembershipRepository membershipRepository) {
+        this.membershipRepository = membershipRepository;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String orgHeader = request.getHeader("X-Org-Id");
+
+        if (orgHeader == null || orgHeader.isBlank()) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        UUID orgId;
+
+        try {
+            orgId = UUID.fromString(orgHeader);
+        } catch (IllegalArgumentException e) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);//400
+            response.setContentType("application/json");
+            response.getWriter().write("{\"message\":\"Invalid X-Org-Id\"}");
+            return;
+        }
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        if (auth == null || !auth.isAuthenticated() || !(auth instanceof JwtAuthenticationToken jwtAuth)) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);//401
+            response.setContentType("application/json");
+            response.getWriter().write("{\"message\":\"Authentication required\"}");
+            return;
+        }
+
+        UUID callerId = UUID.fromString(jwtAuth.getToken().getSubject());
+
+        if (!membershipRepository.existsByOrgIdAndUserId(orgId, callerId)) {
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);//403
+            response.setContentType("application/json");
+            response.getWriter().write("{\"message\":\"Not an org member\"}");
+            return;
+        }
+
+        try {
+            OrgContext.setOrgId(orgId);
+            filterChain.doFilter(request, response);
+        } finally {
+            OrgContext.clear();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds org context enforcement via X-Org-Id header. When the header is present, the request is validated to ensure the caller is authenticated and a member of the specified org, and the orgId is stored in OrgContext for downstream use.

## Related Issue
Closes #19 

## Changes
- Added OrgContext (ThreadLocal) to store orgId per request
- Added OrgContextFilter to validate X-Org-Id and enforce org membership
- Registered filter in SecurityConfig after BearerTokenAuthenticationFilter

## How to Test
- Call endpoints without X-Org-Id → behavior unchanged
- Call endpoints with:
    - valid X-Org-Id where caller is a member → request succeeds
    - valid X-Org-Id where caller is not a member → 403 with JSON message
    - invalid UUID in X-Org-Id → 400
    - missing/invalid auth token with X-Org-Id present → 401

## Notes (optional)
Enforcement is opt-in: only applied when X-Org-Id header is present (multi-tenancy lite).

## Checklist
- [X] Scope is small and focused
- [X] Acceptance criteria met (if Story)
- [X] No secrets committed
