### PR TITLE
Story 5.2 - Ticket CRUD + lifecycle rules

### DIFF
--- a/backend/src/main/java/com/servicedesk/lite/auth/AuthContext.java
+++ b/backend/src/main/java/com/servicedesk/lite/auth/AuthContext.java
@@ -1,0 +1,40 @@
+package com.servicedesk.lite.auth;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.UUID;
+
+public final class AuthContext {
+
+    private AuthContext() {
+
+    }
+
+    public static UUID getUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User not authenticated");
+        }
+        UUID userId;
+        if (auth instanceof JwtAuthenticationToken jwtAuth) {
+            try {
+                return UUID.fromString(jwtAuth.getToken().getSubject());
+            } catch (IllegalArgumentException e) {
+                throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid user id in token");
+            }
+        } else if (auth.getPrincipal() instanceof Jwt jwt) {
+            try {
+                return UUID.fromString(jwt.getSubject());
+            } catch (IllegalArgumentException e) {
+                throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid user id in token");
+            }
+        } else {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Unsupported authentication principal");
+        }
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/tickets/Ticket.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/Ticket.java
@@ -124,4 +124,8 @@ public class Ticket {
     public OffsetDateTime getUpdatedAt() {
         return updatedAt;
     }
+
+    public void setTicketKey(String ticketKey) {
+        this.ticketKey = ticketKey;
+    }
 }

--- a/backend/src/main/java/com/servicedesk/lite/tickets/TicketController.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/TicketController.java
@@ -1,0 +1,33 @@
+package com.servicedesk.lite.tickets;
+
+import com.servicedesk.lite.tickets.dto.CreateTicketRequest;
+import com.servicedesk.lite.tickets.dto.CreateTicketResponse;
+import com.servicedesk.lite.tickets.dto.TicketResponse;
+import com.servicedesk.lite.tickets.dto.UpdateTicketRequest;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/tickets")
+public class TicketController {
+    private final TicketService ticketService;
+
+    public TicketController(TicketService ticketService) {
+        this.ticketService = ticketService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public CreateTicketResponse createTicket(@Valid @RequestBody CreateTicketRequest req) {
+        UUID id = ticketService.createTicket(req);
+        return new CreateTicketResponse(id);
+    }
+
+    @PutMapping("/{ticketId}")
+    public TicketResponse updateTicket(@PathVariable UUID ticketId, @Valid @RequestBody UpdateTicketRequest req) {
+        return ticketService.updateTicket(ticketId, req);
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/tickets/TicketKeyGenerator.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/TicketKeyGenerator.java
@@ -1,0 +1,37 @@
+package com.servicedesk.lite.tickets;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TicketKeyGenerator {
+    private final JdbcTemplate jdbcTemplate;
+    private static final String PREFIX = "SDL";
+    private static final int PAD = 10;
+    private static final String SQL = "select nextval('ticket_key_seq')";
+
+    public TicketKeyGenerator(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    private Long nextSequenceValue() {
+        Long res;
+        res = jdbcTemplate.queryForObject(
+            SQL,
+            Long.class);
+        if (res == null) {
+            throw new IllegalStateException("Result of SQL statement is null in Key Generator");
+        }
+        return res;
+    }
+
+    public String nextKey() {
+        Long seq = nextSequenceValue();
+        return PREFIX + String.format("%0" + PAD + "d", seq);
+    }
+
+    public String nextKey(String prefix) {
+        Long seq = nextSequenceValue();
+        return prefix + String.format("%0" + PAD + "d", seq);
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/tickets/TicketService.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/TicketService.java
@@ -6,6 +6,8 @@ import com.servicedesk.lite.org.Organization;
 import com.servicedesk.lite.org.OrganizationRepository;
 import com.servicedesk.lite.org.context.OrgContext;
 import com.servicedesk.lite.tickets.dto.CreateTicketRequest;
+import com.servicedesk.lite.tickets.dto.TicketResponse;
+import com.servicedesk.lite.tickets.dto.UpdateTicketRequest;
 import com.servicedesk.lite.user.Status;
 import com.servicedesk.lite.user.User;
 import com.servicedesk.lite.user.UserRepository;
@@ -17,15 +19,17 @@ import org.springframework.web.server.ResponseStatusException;
 import java.util.Optional;
 import java.util.UUID;
 
+import static com.servicedesk.lite.tickets.TicketStatus.*;
+
 @Service
-public class TicketsService {
+public class TicketService {
     private final TicketRepository ticketRepository;
     private final TicketKeyGenerator ticketKeyGenerator;
     private final OrganizationRepository organizationRepository;
     private final UserRepository userRepository;
     private final MembershipRepository membershipRepository;
 
-    public TicketsService(TicketRepository ticketRepository, TicketKeyGenerator ticketKeyGenerator, OrganizationRepository organizationRepository, UserRepository userRepository, MembershipRepository membershipRepository) {
+    public TicketService(TicketRepository ticketRepository, TicketKeyGenerator ticketKeyGenerator, OrganizationRepository organizationRepository, UserRepository userRepository, MembershipRepository membershipRepository) {
         this.ticketRepository = ticketRepository;
         this.ticketKeyGenerator = ticketKeyGenerator;
         this.organizationRepository = organizationRepository;
@@ -86,5 +90,71 @@ public class TicketsService {
         }
 
         return user;
+    }
+
+    @Transactional
+    public TicketResponse updateTicket(UUID ticketId, UpdateTicketRequest req) {
+        UUID orgId = OrgContext.getOrgId();
+        Ticket ticket = ticketRepository
+            .findByIdAndOrg_Id(ticketId, orgId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Ticket not found"));
+
+        if (req.getTitle() != null) {
+            ticket.setTitle(req.getTitle());
+        }
+        if (req.getDescription() != null) {
+            ticket.setDescription(req.getDescription());
+        }
+        if (Boolean.TRUE.equals(req.getClearAssignee())) {
+            if (req.getAssigneeUserId() != null) {
+                throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Cannot set and clear assignee at the same time"
+                );
+            }
+            ticket.setAssignee(null);
+        } else if (req.getAssigneeUserId() != null) {
+            User assignee = requireAssignableUser(orgId, req.getAssigneeUserId());
+            ticket.setAssignee(assignee);
+        }
+        if (req.getStatus() != null && req.getStatus() != ticket.getStatus()) {
+            validateStatusTransition(ticket.getStatus(), req.getStatus());
+            ticket.setStatus(req.getStatus());
+        }
+        Ticket savedTicket = ticketRepository.save(ticket);
+
+        return mapToResponse(savedTicket);
+
+    }
+
+    private TicketResponse mapToResponse(Ticket ticket) {
+        TicketResponse res = new TicketResponse();
+        res.setId(ticket.getId());
+        res.setTicketKey(ticket.getTicketKey());
+        res.setStatus(ticket.getStatus());
+        res.setOrgId(ticket.getOrg().getId());
+        res.setCreatedByUserId(ticket.getCreatedBy().getId());
+        res.setAssigneeUserId(
+            ticket.getAssignee() != null ? ticket.getAssignee().getId() : null
+        );
+        res.setCreatedAt(ticket.getCreatedAt());
+        res.setUpdatedAt(ticket.getUpdatedAt());
+        return res;
+    }
+
+    private void validateStatusTransition(TicketStatus from, TicketStatus to) {
+        boolean valid = switch (from) {
+            case OPEN -> to == IN_PROGRESS || to == RESOLVED || to == CLOSED;
+            case IN_PROGRESS -> to == RESOLVED || to == OPEN;
+            case RESOLVED -> to == CLOSED || to == IN_PROGRESS;
+            case CLOSED -> false;
+        };
+
+        if (!valid) {
+            throw new ResponseStatusException(
+                HttpStatus.CONFLICT,
+                "Invalid status transition"
+            );
+        }
     }
 }

--- a/backend/src/main/java/com/servicedesk/lite/tickets/TicketsService.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/TicketsService.java
@@ -1,15 +1,90 @@
 package com.servicedesk.lite.tickets;
 
+import com.servicedesk.lite.auth.AuthContext;
+import com.servicedesk.lite.membership.MembershipRepository;
+import com.servicedesk.lite.org.Organization;
+import com.servicedesk.lite.org.OrganizationRepository;
+import com.servicedesk.lite.org.context.OrgContext;
+import com.servicedesk.lite.tickets.dto.CreateTicketRequest;
+import com.servicedesk.lite.user.Status;
+import com.servicedesk.lite.user.User;
+import com.servicedesk.lite.user.UserRepository;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+import java.util.UUID;
 
 @Service
 public class TicketsService {
     private final TicketRepository ticketRepository;
     private final TicketKeyGenerator ticketKeyGenerator;
+    private final OrganizationRepository organizationRepository;
+    private final UserRepository userRepository;
+    private final MembershipRepository membershipRepository;
 
-    public TicketsService(TicketRepository ticketRepository, TicketKeyGenerator ticketKeyGenerator) {
+    public TicketsService(TicketRepository ticketRepository, TicketKeyGenerator ticketKeyGenerator, OrganizationRepository organizationRepository, UserRepository userRepository, MembershipRepository membershipRepository) {
         this.ticketRepository = ticketRepository;
         this.ticketKeyGenerator = ticketKeyGenerator;
+        this.organizationRepository = organizationRepository;
+        this.userRepository = userRepository;
+        this.membershipRepository = membershipRepository;
     }
-    
+
+    @Transactional
+    public UUID createTicket(CreateTicketRequest req) {
+        UUID orgId = OrgContext.getOrgId();
+        UUID creatorId = AuthContext.getUserId();
+
+        Organization org = requireOrg(orgId);
+        User creator = requireActiveCreator(creatorId);
+
+        Ticket ticket = new Ticket();
+        ticket.setOrg(org);
+        ticket.setCreatedBy(creator);
+        ticket.setTitle(req.getTitle());
+        ticket.setDescription(req.getDescription());
+        ticket.setStatus(TicketStatus.OPEN);
+        ticket.setTicketKey(ticketKeyGenerator.nextKey());
+
+        if (req.getAssigneeUserId() != null) {
+            User assignee = requireAssignableUser(orgId, req.getAssigneeUserId());
+            ticket.setAssignee(assignee);
+        }
+
+        return ticketRepository.save(ticket).getId();
+    }
+
+    private Organization requireOrg(UUID orgId) {
+        Optional<Organization> orgOpt = organizationRepository.findById(orgId);
+        return orgOpt.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Organization not found"));
+    }
+
+    private User requireActiveCreator(UUID userId) {
+        Optional<User> userOpt = userRepository.findById(userId);
+        User user = userOpt.orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User not authenticated"));
+
+        if (user.getStatus() != Status.ACTIVE) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "User is inactive");
+        }
+
+        return user;
+    }
+
+    private User requireAssignableUser(UUID orgId, UUID assigneeUserId) {
+        if (!membershipRepository.existsByOrgIdAndUserId(orgId, assigneeUserId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "User not allowed to assign outside organization");
+        }
+        Optional<User> userOpt = userRepository.findById(assigneeUserId);
+
+        User user = userOpt.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+
+        if (user.getStatus() != Status.ACTIVE) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Assignee must be ACTIVE");
+        }
+
+        return user;
+    }
 }

--- a/backend/src/main/java/com/servicedesk/lite/tickets/TicketsService.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/TicketsService.java
@@ -1,0 +1,15 @@
+package com.servicedesk.lite.tickets;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class TicketsService {
+    private final TicketRepository ticketRepository;
+    private final TicketKeyGenerator ticketKeyGenerator;
+
+    public TicketsService(TicketRepository ticketRepository, TicketKeyGenerator ticketKeyGenerator) {
+        this.ticketRepository = ticketRepository;
+        this.ticketKeyGenerator = ticketKeyGenerator;
+    }
+    
+}

--- a/backend/src/main/java/com/servicedesk/lite/tickets/dto/CreateTicketRequest.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/dto/CreateTicketRequest.java
@@ -1,0 +1,38 @@
+package com.servicedesk.lite.tickets.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.UUID;
+
+public class CreateTicketRequest {
+    @NotBlank
+    private String title;
+
+    private String description;
+
+    private UUID assigneeUserId;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public UUID getAssigneeUserId() {
+        return assigneeUserId;
+    }
+
+    public void setAssigneeUserId(UUID assignedUserId) {
+        this.assigneeUserId = assignedUserId;
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/tickets/dto/CreateTicketResponse.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/dto/CreateTicketResponse.java
@@ -1,0 +1,15 @@
+package com.servicedesk.lite.tickets.dto;
+
+import java.util.UUID;
+
+public class CreateTicketResponse {
+    private UUID id;
+
+    public CreateTicketResponse(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/tickets/dto/TicketResponse.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/dto/TicketResponse.java
@@ -1,0 +1,73 @@
+package com.servicedesk.lite.tickets.dto;
+
+import com.servicedesk.lite.tickets.TicketStatus;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public class TicketResponse {
+    private UUID id;
+    private String ticketKey;
+    private TicketStatus status;
+    private UUID orgId;
+    private UUID assigneeUserId;
+    private UUID createdByUserId;
+    private OffsetDateTime createdAt;
+    private OffsetDateTime updatedAt;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getTicketKey() {
+        return ticketKey;
+    }
+
+    public void setTicketKey(String ticketKey) {
+        this.ticketKey = ticketKey;
+    }
+
+    public UUID getOrgId() {
+        return orgId;
+    }
+
+    public void setOrgId(UUID orgId) {
+        this.orgId = orgId;
+    }
+
+    public UUID getAssigneeUserId() {
+        return assigneeUserId;
+    }
+
+    public void setAssigneeUserId(UUID assigneeUserId) {
+        this.assigneeUserId = assigneeUserId;
+    }
+
+    public UUID getCreatedByUserId() {
+        return createdByUserId;
+    }
+
+    public void setCreatedByUserId(UUID createdByUserId) {
+        this.createdByUserId = createdByUserId;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public OffsetDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(OffsetDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/tickets/dto/TicketResponse.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/dto/TicketResponse.java
@@ -70,4 +70,12 @@ public class TicketResponse {
     public void setUpdatedAt(OffsetDateTime updatedAt) {
         this.updatedAt = updatedAt;
     }
+
+    public TicketStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(TicketStatus status) {
+        this.status = status;
+    }
 }

--- a/backend/src/main/java/com/servicedesk/lite/tickets/dto/UpdateTicketRequest.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/dto/UpdateTicketRequest.java
@@ -44,7 +44,7 @@ public class UpdateTicketRequest {
         this.status = status;
     }
 
-    public Boolean isClearAssignee() {
+    public Boolean getClearAssignee() {
         return clearAssignee;
     }
 

--- a/backend/src/main/java/com/servicedesk/lite/tickets/dto/UpdateTicketRequest.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/dto/UpdateTicketRequest.java
@@ -1,0 +1,54 @@
+package com.servicedesk.lite.tickets.dto;
+
+import com.servicedesk.lite.tickets.TicketStatus;
+
+import java.util.UUID;
+
+public class UpdateTicketRequest {
+    private String title;
+    private String description;
+    private TicketStatus status;
+    private UUID assigneeUserId;
+    private Boolean clearAssignee;
+
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public UUID getAssigneeUserId() {
+        return assigneeUserId;
+    }
+
+    public void setAssigneeUserId(UUID assigneeUserId) {
+        this.assigneeUserId = assigneeUserId;
+    }
+
+    public TicketStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(TicketStatus status) {
+        this.status = status;
+    }
+
+    public Boolean isClearAssignee() {
+        return clearAssignee;
+    }
+
+    public void setClearAssignee(Boolean clearAssignee) {
+        this.clearAssignee = clearAssignee;
+    }
+}

--- a/backend/src/main/resources/db/migration/V5_2__ticket_key_sequence.sql
+++ b/backend/src/main/resources/db/migration/V5_2__ticket_key_sequence.sql
@@ -1,0 +1,7 @@
+-- sequence for ticket key generation
+CREATE SEQUENCE ticket_key_seq
+    START WITH 1
+    INCREMENT BY 1
+    MINVALUE 1
+    NO MAXVALUE
+    CACHE 10;


### PR DESCRIPTION
## Summary
Implements ticket create and update logic, including assignment and status transition rules for Epic 5 Story 5.2.

## Related Issue
Closes #22 

## Changes
- Add AuthContext helper for authenticated user resolution
- Add ticket key sequence and TicketKeyGenerator
- Implement TicketService create/update logic
- Enforce assignment validation (org membership + ACTIVE user)
- Enforce status transition rules
- Add TicketController endpoints for create and update

## How to Test
- Create a ticket → returns 201 with generated id
- Update title/description → returns updated ticket response
- Assign to user in same org → succeeds
- Assign to user outside org → 403 Forbidden
- Assign inactive user → 400 Bad Request
- Invalid status transition → 409 Conflict

## Notes (optional)
- ticket_key is generated using a DB sequence with SDL prefix
- Status transitions enforced in service layer
- Org scoping enforced via OrgContext

## Checklist
- [X] Scope is small and focused
- [X] Acceptance criteria met
- [X] No secrets committed
