### PR TITLE
Story 5.3 - Ticket Comments

### DIFF
--- a/backend/src/main/java/com/servicedesk/lite/tickets/TicketComment.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/TicketComment.java
@@ -73,4 +73,7 @@ public class TicketComment {
         this.body = body;
     }
 
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
 }

--- a/backend/src/main/java/com/servicedesk/lite/tickets/TicketComment.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/TicketComment.java
@@ -1,0 +1,76 @@
+package com.servicedesk.lite.tickets;
+
+import com.servicedesk.lite.org.Organization;
+import com.servicedesk.lite.user.User;
+import jakarta.persistence.*;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "ticket_comments")
+public class TicketComment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id")
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "ticket_id", nullable = false)
+    private Ticket ticket;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "org_id", nullable = false)
+    private Organization org;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "author_user_id", nullable = false)
+    private User author;
+
+    @Column(name = "body", nullable = false, columnDefinition = "text")
+    private String body;
+
+    @Column(name = "created_at", insertable = false, updatable = false, nullable = false)
+    private OffsetDateTime createdAt;
+
+    protected TicketComment() {
+    }
+
+
+    public UUID getId() {
+        return id;
+    }
+
+    public Ticket getTicket() {
+        return ticket;
+    }
+
+    public void setTicket(Ticket ticket) {
+        this.ticket = ticket;
+    }
+
+    public Organization getOrg() {
+        return org;
+    }
+
+    public void setOrg(Organization org) {
+        this.org = org;
+    }
+
+    public User getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(User author) {
+        this.author = author;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+}

--- a/backend/src/main/java/com/servicedesk/lite/tickets/TicketCommentRepository.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/TicketCommentRepository.java
@@ -1,0 +1,11 @@
+package com.servicedesk.lite.tickets;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface TicketCommentRepository extends JpaRepository<TicketComment, UUID> {
+    Page<TicketComment> findAllByOrg_IdAndTicket_IdOrderByCreatedAtAsc(UUID orgId, UUID ticketId, Pageable pageable);
+}

--- a/backend/src/main/java/com/servicedesk/lite/tickets/TicketCommentService.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/TicketCommentService.java
@@ -1,0 +1,71 @@
+package com.servicedesk.lite.tickets;
+
+import com.servicedesk.lite.auth.AuthContext;
+import com.servicedesk.lite.org.context.OrgContext;
+import com.servicedesk.lite.tickets.dto.CreateCommentRequest;
+import com.servicedesk.lite.tickets.dto.TicketCommentResponse;
+import com.servicedesk.lite.user.User;
+import com.servicedesk.lite.user.UserValidator;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.UUID;
+
+@Service
+public class TicketCommentService {
+    private final TicketRepository ticketRepository;
+    private final TicketCommentRepository ticketCommentRepository;
+    private final UserValidator userValidator;
+
+    public TicketCommentService(TicketRepository ticketRepository, TicketCommentRepository ticketCommentRepository, UserValidator userValidator) {
+        this.ticketRepository = ticketRepository;
+        this.ticketCommentRepository = ticketCommentRepository;
+        this.userValidator = userValidator;
+    }
+
+    @Transactional
+    public UUID addComment(UUID ticketId, CreateCommentRequest req) {
+        UUID orgId = OrgContext.getOrgId();
+        UUID authorId = AuthContext.getUserId();
+
+        Ticket ticket = ticketRepository.findByIdAndOrg_Id(ticketId, orgId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Ticket not found"));
+
+        User author = userValidator.requireActiveCreator(authorId);
+
+        TicketComment ticketComment = new TicketComment();
+        ticketComment.setTicket(ticket);
+        ticketComment.setAuthor(author);
+        ticketComment.setOrg(ticket.getOrg());
+        ticketComment.setBody(req.getBody());
+        TicketComment saved = ticketCommentRepository.save(ticketComment);
+
+        return saved.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public Page<TicketCommentResponse> listComments(UUID ticketId, Pageable pageable) {
+        UUID orgId = OrgContext.getOrgId();
+        ticketRepository.findByIdAndOrg_Id(ticketId, orgId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Ticket not found"));
+
+        Page<TicketComment> comments = ticketCommentRepository
+            .findAllByOrg_IdAndTicket_IdOrderByCreatedAtAsc(orgId, ticketId, pageable);
+
+        return comments.map(this::toResponse);
+    }
+
+    private TicketCommentResponse toResponse(TicketComment comment) {
+        TicketCommentResponse dto = new TicketCommentResponse();
+        dto.setId(comment.getId());
+        dto.setAuthorUserId(comment.getAuthor().getId());
+        dto.setBody(comment.getBody());
+        dto.setCreatedAt(comment.getCreatedAt());
+
+        return dto;
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/tickets/TicketController.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/TicketController.java
@@ -1,10 +1,9 @@
 package com.servicedesk.lite.tickets;
 
-import com.servicedesk.lite.tickets.dto.CreateTicketRequest;
-import com.servicedesk.lite.tickets.dto.CreateTicketResponse;
-import com.servicedesk.lite.tickets.dto.TicketResponse;
-import com.servicedesk.lite.tickets.dto.UpdateTicketRequest;
+import com.servicedesk.lite.tickets.dto.*;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,9 +13,11 @@ import java.util.UUID;
 @RequestMapping("/api/tickets")
 public class TicketController {
     private final TicketService ticketService;
+    private final TicketCommentService ticketCommentService;
 
-    public TicketController(TicketService ticketService) {
+    public TicketController(TicketService ticketService, TicketCommentService ticketCommentService) {
         this.ticketService = ticketService;
+        this.ticketCommentService = ticketCommentService;
     }
 
     @PostMapping
@@ -29,5 +30,16 @@ public class TicketController {
     @PutMapping("/{ticketId}")
     public TicketResponse updateTicket(@PathVariable UUID ticketId, @Valid @RequestBody UpdateTicketRequest req) {
         return ticketService.updateTicket(ticketId, req);
+    }
+
+    @PostMapping("/{ticketId}/comments")
+    @ResponseStatus(HttpStatus.CREATED)
+    public CreateCommentResponse createComment(@PathVariable UUID ticketId, @Valid @RequestBody CreateCommentRequest req) {
+        return new CreateCommentResponse(ticketCommentService.addComment(ticketId, req));
+    }
+
+    @GetMapping("/{ticketId}/comments")
+    public Page<TicketCommentResponse> listComments(@PathVariable UUID ticketId, Pageable pageable) {
+        return ticketCommentService.listComments(ticketId, pageable);
     }
 }

--- a/backend/src/main/java/com/servicedesk/lite/tickets/dto/CreateCommentRequest.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/dto/CreateCommentRequest.java
@@ -1,0 +1,16 @@
+package com.servicedesk.lite.tickets.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class CreateCommentRequest {
+    @NotBlank
+    private String body;
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/tickets/dto/CreateCommentResponse.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/dto/CreateCommentResponse.java
@@ -1,0 +1,15 @@
+package com.servicedesk.lite.tickets.dto;
+
+import java.util.UUID;
+
+public class CreateCommentResponse {
+    private final UUID id;
+
+    public CreateCommentResponse(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/tickets/dto/TicketCommentResponse.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/dto/TicketCommentResponse.java
@@ -37,4 +37,8 @@ public class TicketCommentResponse {
         return createdAt;
     }
 
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
 }

--- a/backend/src/main/java/com/servicedesk/lite/tickets/dto/TicketCommentResponse.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/dto/TicketCommentResponse.java
@@ -1,0 +1,40 @@
+package com.servicedesk.lite.tickets.dto;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public class TicketCommentResponse {
+    private UUID id;
+    private UUID authorUserId;
+    private String body;
+    private OffsetDateTime createdAt;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getAuthorUserId() {
+        return authorUserId;
+    }
+
+    public void setAuthorUserId(UUID authorUserId) {
+        this.authorUserId = authorUserId;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+}

--- a/backend/src/main/java/com/servicedesk/lite/user/UserValidator.java
+++ b/backend/src/main/java/com/servicedesk/lite/user/UserValidator.java
@@ -1,0 +1,44 @@
+package com.servicedesk.lite.user;
+
+import com.servicedesk.lite.membership.MembershipRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public class UserValidator {
+    private final UserRepository userRepository;
+    private final MembershipRepository membershipRepository;
+
+    public UserValidator(UserRepository userRepository, MembershipRepository membershipRepository) {
+        this.userRepository = userRepository;
+        this.membershipRepository = membershipRepository;
+    }
+
+    public User requireActiveCreator(UUID userId) {
+        Optional<User> userOpt = userRepository.findById(userId);
+        User user = userOpt.orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User not authenticated"));
+
+        if (user.getStatus() != Status.ACTIVE) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "User is inactive");
+        }
+
+        return user;
+    }
+
+    public User requireAssignableUser(UUID orgId, UUID assigneeUserId) {
+        if (!membershipRepository.existsByOrgIdAndUserId(orgId, assigneeUserId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "User not allowed to assign outside organization");
+        }
+        Optional<User> userOpt = userRepository.findById(assigneeUserId);
+
+        User user = userOpt.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+
+        if (user.getStatus() != Status.ACTIVE) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Assignee must be ACTIVE");
+        }
+
+        return user;
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/user/UserValidator.java
+++ b/backend/src/main/java/com/servicedesk/lite/user/UserValidator.java
@@ -2,11 +2,13 @@ package com.servicedesk.lite.user;
 
 import com.servicedesk.lite.membership.MembershipRepository;
 import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Optional;
 import java.util.UUID;
 
+@Service
 public class UserValidator {
     private final UserRepository userRepository;
     private final MembershipRepository membershipRepository;

--- a/backend/src/main/resources/db/migration/V5_3__create_ticket_comments_table.sql
+++ b/backend/src/main/resources/db/migration/V5_3__create_ticket_comments_table.sql
@@ -1,0 +1,12 @@
+--Ticket comments table
+CREATE TABLE ticket_comments
+(
+    id             UUID PRIMARY KEY     DEFAULT gen_random_uuid(),
+    org_id         UUID        NOT NULL REFERENCES organizations (id),
+    ticket_id      UUID        NOT NULL REFERENCES tickets (id) ON DELETE CASCADE,
+    author_user_id UUID        NOT NULL REFERENCES users (id),
+    body           TEXT        NOT NULL,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_ticket_comments_org_ticket_created_at ON ticket_comments (org_id, ticket_id, created_at ASC);


### PR DESCRIPTION
## Summary
Adds ticket comments support (create + list) for Epic 5 Story 5.3.

## Related Issue
Closes #23

## Changes
- Add Flyway migration for ticket_comments table + index
- Add TicketComment entity and repository
- Add UserValidator shared helper (refactor ticket/comment services to use it)
- Add TicketCommentService for add/list comment logic
- Add ticket comment endpoints under /api/tickets/{ticketId}/comments

## How to Test
- Create a comment:
     - POST /api/tickets/{ticketId}/comments with JSON { "body": "hello" } → 201 Created + comment id
- List comments:
     - GET /api/tickets/{ticketId}/comments?page=0&size=10 → 200 OK + paged results
- Verify org scoping: use a ticketId from another org → 404 Not Found

## Notes (optional)
- Comments are org-scoped and validated via org-scoped ticket lookup
- Pagination supported via Pageable
- ticket_id FK uses ON DELETE CASCADE (comments deleted when ticket is deleted)

## Checklist
- [X] Scope is small and focused
- [X] Acceptance criteria met
- [X] No secrets committed
