### PR TITLE
Story 5.4 - Ticket listing + filtering + pagination

### DIFF
--- a/backend/src/main/java/com/servicedesk/lite/tickets/TicketController.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/TicketController.java
@@ -4,6 +4,8 @@ import com.servicedesk.lite.tickets.dto.*;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -41,5 +43,12 @@ public class TicketController {
     @GetMapping("/{ticketId}/comments")
     public Page<TicketCommentResponse> listComments(@PathVariable UUID ticketId, Pageable pageable) {
         return ticketCommentService.listComments(ticketId, pageable);
+    }
+
+    @GetMapping
+    public Page<TicketSummaryResponse> listTickets(@RequestParam(required = false) TicketStatus status, @RequestParam(required = false) UUID assigneeUserId, @PageableDefault(sort = "createdAt",
+        direction = Sort.Direction.DESC) Pageable pageable) {
+        TicketSearchFilter filter = new TicketSearchFilter(status, assigneeUserId);
+        return ticketService.listTickets(filter, pageable);
     }
 }

--- a/backend/src/main/java/com/servicedesk/lite/tickets/TicketRepository.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/TicketRepository.java
@@ -14,4 +14,8 @@ public interface TicketRepository extends JpaRepository<Ticket, UUID> {
     Page<Ticket> findAllByOrg_Id(UUID orgId, Pageable pageable);
 
     Page<Ticket> findAllByOrg_IdAndStatus(UUID orgId, TicketStatus status, Pageable pageable);
+
+    Page<Ticket> findAllByOrg_IdAndAssignee_Id(UUID orgId, UUID assigneeUserId, Pageable pageable);
+
+    Page<Ticket> findAllByOrg_IdAndStatusAndAssignee_Id(UUID orgId, TicketStatus status, UUID assigneeUserId, Pageable pageable);
 }

--- a/backend/src/main/java/com/servicedesk/lite/tickets/TicketService.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/TicketService.java
@@ -4,11 +4,11 @@ import com.servicedesk.lite.auth.AuthContext;
 import com.servicedesk.lite.org.Organization;
 import com.servicedesk.lite.org.OrganizationRepository;
 import com.servicedesk.lite.org.context.OrgContext;
-import com.servicedesk.lite.tickets.dto.CreateTicketRequest;
-import com.servicedesk.lite.tickets.dto.TicketResponse;
-import com.servicedesk.lite.tickets.dto.UpdateTicketRequest;
+import com.servicedesk.lite.tickets.dto.*;
 import com.servicedesk.lite.user.User;
 import com.servicedesk.lite.user.UserValidator;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -127,5 +127,53 @@ public class TicketService {
                 "Invalid status transition"
             );
         }
+    }
+
+    private TicketSummaryResponse toSummaryResponse(Ticket ticket) {
+        TicketSummaryResponse dto = new TicketSummaryResponse();
+        dto.setId(ticket.getId());
+        dto.setTicketKey(ticket.getTicketKey());
+        dto.setTitle(ticket.getTitle());
+        dto.setStatus(ticket.getStatus());
+        dto.setAssigneeUserId(
+            ticket.getAssignee() != null ? ticket.getAssignee().getId() : null
+        );
+        dto.setCreatedAt(ticket.getCreatedAt());
+        dto.setUpdatedAt(ticket.getUpdatedAt());
+        return dto;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<TicketSummaryResponse> listTickets(TicketSearchFilter filter, Pageable pageable) {
+        UUID orgId = OrgContext.getOrgId();
+        Page<Ticket> page;
+
+        if (filter.getStatus() != null && filter.getAssigneeUserId() != null) {
+            page = ticketRepository.findAllByOrg_IdAndStatusAndAssignee_Id(
+                orgId,
+                filter.getStatus(),
+                filter.getAssigneeUserId(),
+                pageable
+            );
+        } else if (filter.getStatus() != null) {
+            page = ticketRepository.findAllByOrg_IdAndStatus(
+                orgId,
+                filter.getStatus(),
+                pageable
+            );
+        } else if (filter.getAssigneeUserId() != null) {
+            page = ticketRepository.findAllByOrg_IdAndAssignee_Id(
+                orgId,
+                filter.getAssigneeUserId(),
+                pageable
+            );
+        } else {
+            page = ticketRepository.findAllByOrg_Id(
+                orgId,
+                pageable
+            );
+        }
+
+        return page.map(this::toSummaryResponse);
     }
 }

--- a/backend/src/main/java/com/servicedesk/lite/tickets/dto/TicketSearchFilter.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/dto/TicketSearchFilter.java
@@ -1,0 +1,33 @@
+package com.servicedesk.lite.tickets.dto;
+
+import com.servicedesk.lite.tickets.TicketStatus;
+
+import java.util.UUID;
+
+public class TicketSearchFilter {
+
+    private TicketStatus status;
+    private UUID assigneeUserId;
+
+    public TicketSearchFilter(TicketStatus status, UUID assigneeUserId) {
+        this.status = status;
+        this.assigneeUserId = assigneeUserId;
+    }
+
+
+    public TicketStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(TicketStatus status) {
+        this.status = status;
+    }
+
+    public UUID getAssigneeUserId() {
+        return assigneeUserId;
+    }
+
+    public void setAssigneeUserId(UUID assigneeUserId) {
+        this.assigneeUserId = assigneeUserId;
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/tickets/dto/TicketSummaryResponse.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/dto/TicketSummaryResponse.java
@@ -1,0 +1,72 @@
+package com.servicedesk.lite.tickets.dto;
+
+import com.servicedesk.lite.tickets.TicketStatus;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public class TicketSummaryResponse {
+    private UUID id;
+    private String ticketKey;
+    private String title;
+    private TicketStatus status;
+    private UUID assigneeUserId;
+    private OffsetDateTime createdAt;
+    private OffsetDateTime updatedAt;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getTicketKey() {
+        return ticketKey;
+    }
+
+    public void setTicketKey(String ticketKey) {
+        this.ticketKey = ticketKey;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public TicketStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(TicketStatus status) {
+        this.status = status;
+    }
+
+    public UUID getAssigneeUserId() {
+        return assigneeUserId;
+    }
+
+    public void setAssigneeUserId(UUID assigneeUserId) {
+        this.assigneeUserId = assigneeUserId;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public OffsetDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(OffsetDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}


### PR DESCRIPTION
## Summary
Adds ticket listing with pagination and basic filtering (status, assignee) scoped to the current organization.

## Related Issue
Closes #24 

## Changes
- Add GET /api/tickets endpoint with pagination
- Add TicketSearchFilter for request-level filtering (future extensible)
- Add TicketSummaryResponse DTO for list responses
- Extend TicketRepository with org-scoped query methods for status/assignee filters
- Add TicketService.listTickets(...) with filter routing + DTO mapping

## How to Test
- GET /api/tickets?page=0&size=10 returns tickets for the current X-Org-Id only
- Filter by status: GET /api/tickets?status=OPEN&page=0&size=10
- Filter by assignee: GET /api/tickets?assigneeUserId=<uuid>&page=0&size=10
- Filter by both: GET /api/tickets?status=OPEN&assigneeUserId=<uuid>&page=0&size=10
- Switch X-Org-Id to another org and confirm tickets do not leak across orgs

## Notes (optional)
- Default sort is createdAt DESC via @PageableDefault
- Filter DTO is intended to support additional filters later (e.g., search query)

## Checklist
- [X] Scope is small and focused
- [X] Acceptance criteria met
- [X] No secrets committed
