### PR TITLE
Feature/story6.3

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,34 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.1</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
-	<groupId>com.servicedesk</groupId>
-	<artifactId>servicedesk-lite</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<name>servicedesk-lite</name>
-	<description>ServiceDesk-Lite is a backend-focused, full-stack service desk / ticketing system designed to demonstrate real-world backend engineering practices using Java and Spring Boot.</description>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
-	<properties>
-		<java.version>17</java.version>
-	</properties>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>4.0.1</version>
+    <relativePath/> <!-- lookup parent from repository -->
+  </parent>
+  <groupId>com.servicedesk</groupId>
+  <artifactId>servicedesk-lite</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>servicedesk-lite</name>
+  <description>ServiceDesk-Lite is a backend-focused, full-stack service desk / ticketing system designed to demonstrate
+    real-world backend engineering practices using Java and Spring Boot.
+  </description>
+  <url/>
+  <licenses>
+    <license/>
+  </licenses>
+  <developers>
+    <developer/>
+  </developers>
+  <scm>
+    <connection/>
+    <developerConnection/>
+    <tag/>
+    <url/>
+  </scm>
+  <properties>
+    <java.version>17</java.version>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -93,13 +95,20 @@
       <artifactId>flyway-database-postgresql</artifactId>
     </dependency>
 
+    <!-- OpenAPI / Swagger UI -->
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+
   </dependencies>
   <build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/backend/src/main/java/com/servicedesk/lite/auth/AuthController.java
+++ b/backend/src/main/java/com/servicedesk/lite/auth/AuthController.java
@@ -1,6 +1,7 @@
 package com.servicedesk.lite.auth;
 
 import com.servicedesk.lite.auth.dto.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
+@Tag(name = "Auth", description = "Authentication and current-user endpoints")
 @RestController
 @RequestMapping("/api/auth")
 public class AuthController {
@@ -30,6 +32,6 @@ public class AuthController {
 
     @GetMapping("/me")
     public MeResponse me(@AuthenticationPrincipal Jwt jwt) {
-        return new MeResponse(jwt.getSubject(), jwt.getClaimAsString("email"),jwt.getClaimAsString("status") );
+        return new MeResponse(jwt.getSubject(), jwt.getClaimAsString("email"), jwt.getClaimAsString("status"));
     }
 }

--- a/backend/src/main/java/com/servicedesk/lite/auth/AuthController.java
+++ b/backend/src/main/java/com/servicedesk/lite/auth/AuthController.java
@@ -1,6 +1,7 @@
 package com.servicedesk.lite.auth;
 
 import com.servicedesk.lite.auth.dto.*;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -19,17 +20,20 @@ public class AuthController {
         this.authService = authService;
     }
 
+    @Operation(summary = "Register user")
     @PostMapping("/register")
     public RegisterResponse register(@Valid @RequestBody RegisterRequest request) {
         UUID id = authService.register(request);
         return new RegisterResponse(id);
     }
 
+    @Operation(summary = "Login user")
     @PostMapping("/login")
     public LoginResponse login(@Valid @RequestBody LoginRequest request) {
         return authService.login(request);
     }
 
+    @Operation(summary = "Get current user")
     @GetMapping("/me")
     public MeResponse me(@AuthenticationPrincipal Jwt jwt) {
         return new MeResponse(jwt.getSubject(), jwt.getClaimAsString("email"), jwt.getClaimAsString("status"));

--- a/backend/src/main/java/com/servicedesk/lite/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/servicedesk/lite/config/OpenApiConfig.java
@@ -1,0 +1,29 @@
+package com.servicedesk.lite.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+    @Bean
+    OpenAPI customOpenAPI() {
+        return new OpenAPI()
+            .info(new Info()
+                .title("ServiceDesk-Lite API")
+                .version("v1")
+                .description("Backend API for ServiceDesk-Lite application")
+            ).components(new Components()
+                .addSecuritySchemes("bearerAuth", new SecurityScheme()
+                    .type(SecurityScheme.Type.HTTP)
+                    .scheme("bearer")
+                    .bearerFormat("JWT")
+                )
+            ).addSecurityItem(new SecurityRequirement().addList("bearerAuth")
+            );
+    }
+}

--- a/backend/src/main/java/com/servicedesk/lite/org/MembershipController.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/MembershipController.java
@@ -3,6 +3,7 @@ package com.servicedesk.lite.org;
 import com.servicedesk.lite.org.dto.AddMemberRequest;
 import com.servicedesk.lite.org.dto.AddMemberResponse;
 import com.servicedesk.lite.org.dto.MembershipSummaryResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -25,6 +26,7 @@ public class MembershipController {
         this.organizationListingService = organizationListingService;
     }
 
+    @Operation(summary = "Add member to organization")
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public AddMemberResponse createMembership(@PathVariable UUID orgId, @Valid @RequestBody AddMemberRequest req, @AuthenticationPrincipal Jwt jwt) {
@@ -33,6 +35,7 @@ public class MembershipController {
         return new AddMemberResponse(membershipId);
     }
 
+    @Operation(summary = "List organization members")
     @GetMapping
     public List<MembershipSummaryResponse> listOrgMembers(@PathVariable UUID orgId, @AuthenticationPrincipal Jwt jwt) {
         UUID callerId = UUID.fromString(jwt.getSubject());

--- a/backend/src/main/java/com/servicedesk/lite/org/MembershipController.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/MembershipController.java
@@ -3,6 +3,7 @@ package com.servicedesk.lite.org;
 import com.servicedesk.lite.org.dto.AddMemberRequest;
 import com.servicedesk.lite.org.dto.AddMemberResponse;
 import com.servicedesk.lite.org.dto.MembershipSummaryResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
+@Tag(name = "Memberships", description = "Organization membership management endpoints")
 @RestController
 @RequestMapping("/api/organizations/{orgId}/memberships")
 public class MembershipController {

--- a/backend/src/main/java/com/servicedesk/lite/org/OrganizationController.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/OrganizationController.java
@@ -3,6 +3,7 @@ package com.servicedesk.lite.org;
 import com.servicedesk.lite.org.dto.CreateOrganizationRequest;
 import com.servicedesk.lite.org.dto.CreateOrganizationResponse;
 import com.servicedesk.lite.org.dto.OrganizationSummaryResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -25,6 +26,7 @@ public class OrganizationController {
         this.organizationListingService = organizationListingService;
     }
 
+    @Operation(summary = "Create organization")
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public CreateOrganizationResponse createOrganization(@Valid @RequestBody CreateOrganizationRequest req, @AuthenticationPrincipal Jwt jwt) {
@@ -33,6 +35,7 @@ public class OrganizationController {
         return new CreateOrganizationResponse(orgId);
     }
 
+    @Operation(summary = "List my organizations")
     @GetMapping
     public List<OrganizationSummaryResponse> listMyOrganizations(@AuthenticationPrincipal Jwt jwt) {
         UUID userId = UUID.fromString(jwt.getSubject());

--- a/backend/src/main/java/com/servicedesk/lite/org/OrganizationController.java
+++ b/backend/src/main/java/com/servicedesk/lite/org/OrganizationController.java
@@ -3,6 +3,7 @@ package com.servicedesk.lite.org;
 import com.servicedesk.lite.org.dto.CreateOrganizationRequest;
 import com.servicedesk.lite.org.dto.CreateOrganizationResponse;
 import com.servicedesk.lite.org.dto.OrganizationSummaryResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
+@Tag(name = "Organizations", description = "Organization management endpoints")
 @RestController
 @RequestMapping("/api/organizations")
 public class OrganizationController {

--- a/backend/src/main/java/com/servicedesk/lite/tickets/TicketController.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/TicketController.java
@@ -1,6 +1,7 @@
 package com.servicedesk.lite.tickets;
 
 import com.servicedesk.lite.tickets.dto.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
+@Tag(name = "Tickets", description = "Ticket and ticket comment endpoints")
 @RestController
 @RequestMapping("/api/tickets")
 public class TicketController {
@@ -44,7 +46,7 @@ public class TicketController {
     public Page<TicketCommentResponse> listComments(@PathVariable UUID ticketId, Pageable pageable) {
         return ticketCommentService.listComments(ticketId, pageable);
     }
-
+    
     @GetMapping
     public Page<TicketSummaryResponse> listTickets(@RequestParam(required = false) TicketStatus status, @RequestParam(required = false) UUID assigneeUserId, @PageableDefault(sort = "createdAt",
         direction = Sort.Direction.DESC) Pageable pageable) {

--- a/backend/src/main/java/com/servicedesk/lite/tickets/TicketController.java
+++ b/backend/src/main/java/com/servicedesk/lite/tickets/TicketController.java
@@ -1,6 +1,7 @@
 package com.servicedesk.lite.tickets;
 
 import com.servicedesk.lite.tickets.dto.*;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
@@ -24,6 +25,7 @@ public class TicketController {
         this.ticketCommentService = ticketCommentService;
     }
 
+    @Operation(summary = "Create ticket")
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public CreateTicketResponse createTicket(@Valid @RequestBody CreateTicketRequest req) {
@@ -31,22 +33,26 @@ public class TicketController {
         return new CreateTicketResponse(id);
     }
 
+    @Operation(summary = "Update ticket")
     @PutMapping("/{ticketId}")
     public TicketResponse updateTicket(@PathVariable UUID ticketId, @Valid @RequestBody UpdateTicketRequest req) {
         return ticketService.updateTicket(ticketId, req);
     }
 
+    @Operation(summary = "Add comment to ticket")
     @PostMapping("/{ticketId}/comments")
     @ResponseStatus(HttpStatus.CREATED)
     public CreateCommentResponse createComment(@PathVariable UUID ticketId, @Valid @RequestBody CreateCommentRequest req) {
         return new CreateCommentResponse(ticketCommentService.addComment(ticketId, req));
     }
 
+    @Operation(summary = "List ticket comments")
     @GetMapping("/{ticketId}/comments")
     public Page<TicketCommentResponse> listComments(@PathVariable UUID ticketId, Pageable pageable) {
         return ticketCommentService.listComments(ticketId, pageable);
     }
-    
+
+    @Operation(summary = "List tickets")
     @GetMapping
     public Page<TicketSummaryResponse> listTickets(@RequestParam(required = false) TicketStatus status, @RequestParam(required = false) UUID assigneeUserId, @PageableDefault(sort = "createdAt",
         direction = Sort.Direction.DESC) Pageable pageable) {


### PR DESCRIPTION
## Summary
This PR adds API documentation using Swagger UI via springdoc-openapi.

It enables interactive exploration of the ServiceDesk-Lite API and improves developer experience by organizing endpoints and providing clear summaries.

## Related Issue
Closes #28 

## Changes
- Added springdoc-openapi dependency (Boot 4 compatible version)
- Enabled Swagger UI for the application
- Added controller-level @Tag annotations to group endpoints
- Added @Operation(summary = "...") to core endpoints for readability
- Added OpenAPI configuration with:
    - API title (ServiceDesk-Lite API)
    - version (v1)
    - description
- Configured JWT bearer authentication support in Swagger UI

## How to Test
Steps to verify this PR works:

1. Run the application
2. Navigate to:
    - /swagger-ui.html or
    - /swagger-ui/index.html
3. Verify:
- API title displays "ServiceDesk-Lite API"
- Endpoints are grouped under:
    - Auth
    - Organizations
    - Memberships
    - Tickets
- Each endpoint has a readable summary
4. Test authentication:
    - Click Authorize
    - Provide a valid JWT
    - Call secured endpoints successfully

## Notes
Swagger UI is intended for development/testing and not restricted by security rules

## Checklist
- [X] Scope is small and focused
- [X] Acceptance criteria met (if Story)
- [X] Docs updated (if needed)
- [X] No secrets committed
